### PR TITLE
bootstrap: install python3 from software collections

### DIFF
--- a/slave/bootstrap.sh
+++ b/slave/bootstrap.sh
@@ -8,6 +8,11 @@ curl 'http://copr.fedorainfracloud.org/coprs/lnykryn/systemd-centosci-environmen
 yum -q -y update
 yum -q -y install systemd-ci-environment python-lxml
 
+# install python3
+yum -q -y install centos-release-scl
+yum-config-manager --enable rhel-server-rhscl-7-rpms
+yum -q -y install rh-python35
+
 test -e systemd && rm -rf systemd
 git clone https://github.com/systemd/systemd.git
 


### PR DESCRIPTION
I am currently working on https://github.com/systemd/systemd/pull/5354
and PR also introduces first python based test to TEST-* series. This
commit is prerequisite for running that test in Cent OS CI.

https://www.softwarecollections.org/en/scls/rhscl/rh-python35/