### PR TITLE
meson: fix nobody user and group

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -59,7 +59,12 @@ git describe
 #   - slow-tests=true: enable slow tests => enables fuzzy tests using libasan
 #     installed above
 #   - install-tests=true: necessary for test/TEST-24-UNIT-TESTS
-CFLAGS='-g -O0 -ftrapv' meson build -Dslow-tests=true -Dinstall-tests=true -Ddbuspolicydir=/etc/dbus-1/system.d
+CFLAGS='-g -O0 -ftrapv' meson build \
+      -Dslow-tests=true \
+      -Dinstall-tests=true \
+      -Ddbuspolicydir=/etc/dbus-1/system.d \
+      -Dnobody-user=nfsnobody \
+      -Dnobody-group=nfsnobody
 ninja-build -C build
 ninja-build -C build install
 


### PR DESCRIPTION
CentOS uses nfsnobody as UID/GID 65534.

Not tested. But I hope this fixes two warnings during build.