### PR TITLE
Support artifact exporting

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -2,6 +2,14 @@
 
 . "$(dirname "$0")/common.sh" "testsuite-logs" || exit 1
 
+# EXIT signal handler
+function at_exit {
+    set +e
+    exectask "Dump system journal" "journalctl.log" "journalctl -b --no-pager"
+}
+
+trap at_exit EXIT
+
 ### SETUP PHASE ###
 # Exit on error in the setup phase
 set -e


### PR DESCRIPTION
This PR introduces artifact exporting in the CentOS CI infrastructure. 

The shenanigans with the environment and rsync password files are necessary to make the directory structure on the [artifact server](http://artifacts.ci.centos.org/systemd/) at least a little bit pretty, and to not expose sensitive information (like rsync password). Nevertheless, the directory structure is still far from pretty, at least in my opinion (`systemd/<branch|commit|pr>/<log-folder>/<log-file>.log>`) but let's see how it's going to work out.
