### PR TITLE
Run the integration test suite under KVM as well

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -73,7 +73,6 @@ INITRD_PATH="/boot/initramfs-$(uname -r).img"
 KERNEL_PATH="/boot/vmlinuz-$(uname -r)"
 [ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
 make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1 INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND=debug
-rm -f /usr/bin/qemu-kvm
 
 # Install the compiled systemd
 ninja-build -C build install

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -25,7 +25,7 @@ fi
 
 # Install test dependencies
 exectask "Install test dependencies" "yum-depinstall.log" \
-    "yum -y install net-tools strace nc busybox e2fsprogs quota dnsmasq"
+    "yum -y install net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm"
 
 set +e
 
@@ -37,12 +37,15 @@ cd systemd
 sed -i 's/test_exec_privatenetwork,//' src/test/test-execute.c
 exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
 
-# Run the internal integration testsuite
-INITRD_PATH="/boot/initramfs-$(uname -r).img"
-KERNEL_PATH="/boot/vmlinuz-$(uname -r)"
+## Integration test suite ##
 SKIP_LIST=(
     "test/TEST-16-EXTEND-TIMEOUT"
 )
+INITRD_PATH="/boot/initramfs-$(uname -r).img"
+KERNEL_PATH="/boot/vmlinuz-$(uname -r)"
+
+[ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
+qemu-kvm --version
 
 for t in test/TEST-??-*; do
     if [[ " ${SKIP_LIST[@]} " =~ " $t " ]]; then
@@ -52,7 +55,7 @@ for t in test/TEST-??-*; do
     exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH"
 done
 
-# Other integration tests
+## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"
 #    "test/test-network/systemd-networkd-tests.py"

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -52,7 +52,7 @@ for t in test/TEST-??-*; do
         echo -e "\n[SKIP] Skipping test $t"
         continue
     fi
-    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH"
+    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND='user_namespace.enable=1'"
 done
 
 ## Other integration tests ##

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -39,7 +39,9 @@ exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
 
 ## Integration test suite ##
 SKIP_LIST=(
-    "test/TEST-16-EXTEND-TIMEOUT"
+    "test/TEST-02-CRYPTSETUP" # flaky test (https://github.com/systemd/systemd/issues/10093)
+    "test/TEST-10-ISSUE-2467" # https://github.com/systemd/systemd/pull/7494#discussion_r155635695
+    "test/TEST-16-EXTEND-TIMEOUT" # flaky test
 )
 INITRD_PATH="/boot/initramfs-$(uname -r).img"
 KERNEL_PATH="/boot/vmlinuz-$(uname -r)"


### PR DESCRIPTION
Let's try running the integration test suite under both systemd-nspawn and KVM.