### PR TITLE
Fetch artifacts even when test suite fails

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -58,6 +58,8 @@ def remote_exec(host, remote_cmd, expected_ret = 0, ignore_ret = False):
     if not ignore_ret and ret != expected_ret:
         raise Exception("Remote command returned code %d, expected %d. Bailing out." % (ret, expected_ret))
 
+    return ret
+
 def ping_host(host):
 
     cmd = [ '/usr/bin/ping', '-q', '-c', '1', '-W', '10', host ]
@@ -183,8 +185,10 @@ def main():
         reboot_host(host)
 
         cmd = "%s/agent/testsuite.sh" % git_name
-        remote_exec(host, cmd)
+        ret = remote_exec(host, cmd, ignore_ret=True)
         fetch_artifacts(host, "~/testsuite-logs*", artifact_dir)
+        if ret != 0:
+            raise Exception("Command returned non-zero exit code (%d)" % ret)
         reboot_host(host)
 
         #cmd = "%s/agent/beakerlib-testsuite.sh" % git_name


### PR DESCRIPTION
Quick workaround to fetch artifacts even when the test suite fails instead of just bailing out with an exception. I'm planning to rewrite most of the `agent-control.py` script anyway, when I have a some free time, so it's pointless to implement a more robust solution.