### PR TITLE
Temporarily disable TEST-20-MAINPIDGAMES...

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -42,6 +42,7 @@ SKIP_LIST=(
     "test/TEST-02-CRYPTSETUP" # flaky test (https://github.com/systemd/systemd/issues/10093)
     "test/TEST-10-ISSUE-2467" # https://github.com/systemd/systemd/pull/7494#discussion_r155635695
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
+    "test/TEST-20-MAINPIDGAMES" # Temporary, until the /dev/shm issue is resolved
 )
 INITRD_PATH="/boot/initramfs-$(uname -r).img"
 KERNEL_PATH="/boot/vmlinuz-$(uname -r)"


### PR DESCRIPTION
until the issue with /dev/shm and noexec is resolved

This is a very quick workaround for the `/dev/shm` and `noexec` issue introduced somewhere in master, see https://github.com/systemd/systemd/pull/11226