### PR TITLE
bootstrap: update the initrd before the sanity check

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -92,6 +92,12 @@ esac
 echo -n "Checked out version "
 git describe
 
+# It's impossible to keep the local SELinux policy database up-to-date with
+# arbitrary pull request branches we're testing against.
+# Disable SELinux on the test hosts and avoid false positives.
+setenforce 0
+echo SELINUX=disabled >/etc/selinux/config
+
 # Compile systemd
 #   - slow-tests=true: enable slow tests => enables fuzzy tests using libasan
 #     installed above
@@ -122,11 +128,6 @@ ninja-build -C build install
     [ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
     make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1 INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND=debug
 ) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
-
-# It's impossible to keep the local SELinux policy database up-to-date with
-#arbitrary pull request branches we're testing against.
-# Disable SELinux on the test hosts and avoid false positives.
-echo SELINUX=disabled >/etc/selinux/config
 
 # Readahead is dead in systemd upstream
 rm -f /usr/lib/systemd/system/systemd-readahead-done.service


### PR DESCRIPTION
The original initrd provided by CentOS is pretty old (v219) and causes
several intermittent issues during the sanity check. Regenerating the
initrd however requires the new systemd to be installed, so let's
reorder the phases to ensure it.

@evverx I looked into the possibility of generating the initrd without installing the new systemd beforehand, and even though it is possible by writing a custom dracut config similar to the [default one](https://github.com/dracutdevs/dracut/blob/master/dracut.conf.d/fedora.conf.example), I'd say it's more fragile than just installing the new systemd and running the sanity check right after that.