### PR TITLE
Set test timeouts

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -126,7 +126,7 @@ ninja-build -C build install
     # trying to test
     dracut -f --filesystems ext4
     [ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
-    make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1 INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND=debug
+    make -C test/TEST-01-BASIC clean setup run clean-again QEMU_TIMEOUT=600 TEST_NO_NSPAWN=1 INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND=debug
 ) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
 
 # Readahead is dead in systemd upstream

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -57,6 +57,11 @@ for t in test/TEST-??-*; do
     fi
 
     rm -fr /var/tmp/systemd-test*
+
+    # Set timeouts for QEMU and systemd-nspawn tests (see systemd/test/test-functions)
+    export QEMU_TIMEOUT=600
+    export NSPAWN_TIMEOUT=600
+
     exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND='user_namespace.enable=1'"
     # Each integration test dumps the system journal when something breaks
     [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR/${t##*/}"

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -44,8 +44,6 @@ SKIP_LIST=(
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
     "test/TEST-20-MAINPIDGAMES" # Temporary, until the /dev/shm issue is resolved
 )
-INITRD_PATH="/boot/initramfs-$(uname -r).img"
-KERNEL_PATH="/boot/vmlinuz-$(uname -r)"
 
 [ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
 qemu-kvm --version
@@ -58,11 +56,17 @@ for t in test/TEST-??-*; do
 
     rm -fr /var/tmp/systemd-test*
 
-    # Set timeouts for QEMU and systemd-nspawn tests (see systemd/test/test-functions)
+    ## Configure test environment
+    # Explicitly set paths to initramfs and kernel images (for QEMU tests)
+    export INITRD="/boot/initramfs-$(uname -r).img"
+    export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
+    # Explicitly enable user namespaces
+    export KERNEL_APPEND="user_namespace.enable=1"
+    # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
     export QEMU_TIMEOUT=600
     export NSPAWN_TIMEOUT=600
 
-    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again INITRD=$INITRD_PATH KERNEL_BIN=$KERNEL_PATH KERNEL_APPEND='user_namespace.enable=1'"
+    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again"
     # Each integration test dumps the system journal when something breaks
     [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR/${t##*/}"
 done


### PR DESCRIPTION
Set timeouts for integration tests using QEMU/nspawn. This could have been done in Jenkins instead, but here we have more granular control about what and where the timeouts should be.

Also, I replaced the inline bash env variable syntax with exports, as it's more readable given the amount of env variable we're currently setting.