### PR TITLE
Add modified script versions to allow downstream testing

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -311,6 +311,8 @@ if __name__ == "__main__":
             help="List currectly allocated nodes")
     parser.add_argument("--pr",
             help="Pull request ID to check out (systemd repository)")
+    parser.add_argument("--rhel7", action="store_const", const=True,
+            help="Use RHEL7 scripts for testing")
     parser.add_argument("--version", default="7",
             help="CentOS version")
     args = parser.parse_args()
@@ -361,13 +363,19 @@ if __name__ == "__main__":
             ac.execute_remote_command(node, command)
 
         logging.info("PHASE 2: Bootstrap (branch: {})".format(branch))
-        command = "{}/agent/bootstrap.sh {}".format(GITHUB_CI_REPO, branch)
+        if args.rhel7:
+            command = "{}/agent/bootstrap-rhel7.sh {}".format(GITHUB_CI_REPO, branch)
+        else:
+            command = "{}/agent/bootstrap.sh {}".format(GITHUB_CI_REPO, branch)
         ac.execute_remote_command(node, command, artifacts_dir="~/bootstrap-logs*")
 
         ac.reboot_node(node)
 
         logging.info("PHASE 3: Upstream testsuite")
-        command = "{}/agent/testsuite.sh".format(GITHUB_CI_REPO)
+        if args.rhel7:
+            command = "{}/agent/testsuite-rhel7.sh".format(GITHUB_CI_REPO)
+        else:
+            command = "{}/agent/testsuite.sh".format(GITHUB_CI_REPO)
         ac.execute_remote_command(node, command, artifacts_dir="~/testsuite-logs*")
 
     except SIGTERMException:

--- a/agent/bootstrap-rhel7.sh
+++ b/agent/bootstrap-rhel7.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/bash
+
+. "$(dirname "$0")/common.sh" "bootstrap-logs" || exit 1
+
+# EXIT signal handler
+function at_exit {
+    # Let's collect some build-related logs
+    set +e
+    [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR"
+    exectask "Dump system journal" "journalctl-bootstrap.log" "journalctl -b --no-pager"
+}
+
+trap at_exit EXIT
+
+# All commands from this script are fundamental, ensure they all pass
+# before continuing (or die trying)
+set -e
+set -o pipefail
+
+# Install necessary dependencies
+yum -q -y install rpm-build yum-utils
+yum-builddep -y systemd
+
+# Fetch the downstream systemd repo
+test -e systemd-rhel && rm -rf systemd-rhel
+git clone https://github.com/lnykryn/systemd-rhel.git
+pushd systemd-rhel
+
+echo "$0 called with argument '$1'"
+
+# Checkout to the requsted branch:
+#   1) if pr:XXX where XXX is a pull request ID is passed to the script,
+#      the corresponding branch for this PR is be checked out
+#   2) if any other string except pr:* is passed, it's used as a branch
+#      name to check out
+#   3) if the script is called without arguments, the default (possibly master)
+#      branch is used
+case $1 in
+    pr:*)
+        git fetch -fu origin "refs/pull/${1#pr:}/merge:pr"
+        git checkout pr
+        ;;
+
+    "")
+        ;;
+
+    *)
+        git checkout "$1"
+        ;;
+esac
+
+echo -n "Checked out version "
+git describe
+
+# It's impossible to keep the local SELinux policy database up-to-date with
+# arbitrary pull request branches we're testing against.
+# Disable SELinux on the test hosts and avoid false positives.
+setenforce 0
+echo SELINUX=disabled >/etc/selinux/config
+
+# Compile systemd
+(
+    ./autogen.sh
+    CONFIGURE_OPTS=(
+        --with-sysvinit-path=/etc/rc.d/init.d
+        --with-rc-local-script-path-start=/etc/rc.d/rc.local
+        --disable-timesyncd
+        --disable-kdbus
+        --disable-terminal
+        --enable-gtk-doc
+        --enable-compat-libs
+        --disable-sysusers
+        --disable-ldconfig
+        --enable-lz4
+    )
+    ./configure "${CONFIGURE_OPTS[@]}"
+    make
+    make install
+) 2>&1 | tee "$LOGDIR/build.log"
+
+## FIXME: the integration testsuite is currently broken on RHEL7
+# Let's check if the new systemd at least boots before rebooting the system
+#(
+#    ## Configure test environment
+#    # Set timeout for systemd-nspawn tests to kill them in case they get stuck
+#    export NSPAWN_TIMEOUT=600
+#    # Disable QEMU version of the test
+#    export TEST_NO_QEMU=1
+#
+#    make -C test/TEST-01-BASIC clean setup run clean-again
+#) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
+
+echo "-----------------------------"
+echo "- REBOOT THE MACHINE BEFORE -"
+echo "-         CONTINUING        -"
+echo "-----------------------------"

--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/bash
+
+. "$(dirname "$0")/common.sh" "testsuite-logs" || exit 1
+
+# EXIT signal handler
+function at_exit {
+    set +e
+    exectask "Dump system journal" "journalctl-testsuite.log" "journalctl -b --no-pager"
+}
+
+trap at_exit EXIT
+
+### SETUP PHASE ###
+# Exit on error in the setup phase
+set -e
+
+# Install test dependencies
+exectask "Install test dependencies" "yum-depinstall.log" \
+    "yum -y install net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm"
+
+set +e
+
+### TEST PHASE ###
+cd systemd-rhel
+
+# Run the internal unit tests (make check)
+exectask "make check" "make-check.log" "make check"
+
+
+## FIXME: the integration testsuite is currently broken on RHEL7
+if false; then
+## Integration test suite ##
+
+[ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
+qemu-kvm --version
+
+for t in test/TEST-??-*; do
+    if [[ " ${SKIP_LIST[@]} " =~ " $t " ]]; then
+        echo -e "\n[SKIP] Skipping test $t"
+        continue
+    fi
+
+    rm -fr /var/tmp/systemd-test*
+
+    ## Configure test environment
+    # Explicitly set paths to initramfs and kernel images (for QEMU tests)
+    export INITRD="/boot/initramfs-$(uname -r).img"
+    export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
+    # Explicitly enable user namespaces
+    export KERNEL_APPEND="user_namespace.enable=1"
+    # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
+    export QEMU_TIMEOUT=600
+    export NSPAWN_TIMEOUT=600
+
+    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again"
+    # Each integration test dumps the system journal when something breaks
+    [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR/${t##*/}"
+done
+
+## Other integration tests ##
+TEST_LIST=(
+    "test/test-exec-deserialization.py"
+#    "test/test-network/systemd-networkd-tests.py"
+)
+
+for t in "${TEST_LIST[@]}"; do
+    exectask "$t" "${t##*/}.log" "./$t"
+done
+
+fi
+
+# Summary
+echo
+echo "TEST SUMMARY:"
+echo "-------------"
+echo "PASSED: $PASSED"
+echo "FAILED: $FAILED"
+echo "TOTAL:  $((PASSED + FAILED))"
+echo
+echo "FAILED TASKS:"
+echo "-------------"
+for task in "${FAILED_LIST[@]}"; do
+    echo  "$task"
+done
+
+exit $FAILED


### PR DESCRIPTION
As we'd like to use the CentOS CI to test downstream systemd (RHEL 7, https://github.com/lnykryn/systemd-rhel), so let's add modified versions of CI scripts to allow that. ~~To make things less complicated, they're in a separate folder and should be used as replacements of scripts in the `agent` folder.~~