### PR TITLE
rhel7: reenable integration tests

### DIFF
--- a/agent/bootstrap-rhel7.sh
+++ b/agent/bootstrap-rhel7.sh
@@ -74,7 +74,7 @@ echo SELINUX=disabled >/etc/selinux/config
         --enable-lz4
     )
     ./configure "${CONFIGURE_OPTS[@]}"
-    make
+    make -j 8
     make install
 ) 2>&1 | tee "$LOGDIR/build.log"
 

--- a/agent/bootstrap-rhel7.sh
+++ b/agent/bootstrap-rhel7.sh
@@ -18,7 +18,8 @@ set -e
 set -o pipefail
 
 # Install necessary dependencies
-yum -q -y install rpm-build yum-utils
+# - systemd-* packages are necessary for correct users/groups to be created
+yum -q -y install systemd-journal-gateway systemd-resolved rpm-build yum-utils net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm
 yum-builddep -y systemd
 
 # Fetch the downstream systemd repo
@@ -86,7 +87,7 @@ echo SELINUX=disabled >/etc/selinux/config
     # Disable QEMU version of the test
     export TEST_NO_QEMU=1
 
-    make -C test/TEST-01-BASIC clean setup run clean-again
+    make -C test/TEST-01-BASIC clean setup run
 ) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
 
 echo "-----------------------------"

--- a/agent/bootstrap-rhel7.sh
+++ b/agent/bootstrap-rhel7.sh
@@ -78,17 +78,16 @@ echo SELINUX=disabled >/etc/selinux/config
     make install
 ) 2>&1 | tee "$LOGDIR/build.log"
 
-## FIXME: the integration testsuite is currently broken on RHEL7
 # Let's check if the new systemd at least boots before rebooting the system
-#(
-#    ## Configure test environment
-#    # Set timeout for systemd-nspawn tests to kill them in case they get stuck
-#    export NSPAWN_TIMEOUT=600
-#    # Disable QEMU version of the test
-#    export TEST_NO_QEMU=1
-#
-#    make -C test/TEST-01-BASIC clean setup run clean-again
-#) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
+(
+    ## Configure test environment
+    # Set timeout for systemd-nspawn tests to kill them in case they get stuck
+    export NSPAWN_TIMEOUT=600
+    # Disable QEMU version of the test
+    export TEST_NO_QEMU=1
+
+    make -C test/TEST-01-BASIC clean setup run clean-again
+) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
 
 echo "-----------------------------"
 echo "- REBOOT THE MACHINE BEFORE -"

--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -16,7 +16,7 @@ set -e
 
 # Install test dependencies
 exectask "Install test dependencies" "yum-depinstall.log" \
-    "yum -y install net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm"
+    "yum -y install net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm python-enum34"
 
 set +e
 

--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -26,9 +26,6 @@ cd systemd-rhel
 # Run the internal unit tests (make check)
 exectask "make check" "make-check.log" "make check"
 
-
-## FIXME: the integration testsuite is currently broken on RHEL7
-if false; then
 ## Integration test suite ##
 
 [ ! -f /usr/bin/qemu-kvm ] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
@@ -66,8 +63,6 @@ TEST_LIST=(
 for t in "${TEST_LIST[@]}"; do
     exectask "$t" "${t##*/}.log" "./$t"
 done
-
-fi
 
 # Summary
 echo

--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -49,7 +49,7 @@ for t in test/TEST-??-*; do
     export QEMU_TIMEOUT=600
     export NSPAWN_TIMEOUT=600
 
-    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again"
+    exectask "$t" "${t##*/}.log" "make -C $t clean setup run"
     # Each integration test dumps the system journal when something breaks
     [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR/${t##*/}"
 done


### PR DESCRIPTION
Integration tests on RHEL7 should be fixed by lnykryn/systemd-rhel#263.