### PR TITLE
rhel8: create systemd-resolve user & group

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -167,6 +167,10 @@ echo SELINUX=disabled >/etc/selinux/config
 # Install the compiled systemd
 ninja-build -C build install
 
+# Create necessary systemd users/groups
+getent group systemd-resolve &>/dev/null || groupadd -r -g 193 systemd-resolve 2>&1
+getent passwd systemd-resolve &>/dev/null || useradd -r -u 193 -l -g systemd-resolve -d / -s /sbin/nologin -c "systemd Resolver" systemd-resolve &>/dev/null
+
 # Let's check if the new systemd at least boots before rebooting the system
 # As the CentOS' systemd-nspawn version is too old, we have to use QEMU
 (


### PR DESCRIPTION
On RHEL 8 the default sysusers config file is missing the
systemd-resolve user, which is created during systemd-resolved RPM
installation. As we're compiling systemd from the source, create the
user and group manually