### PR TITLE
testsuite: re-enable TEST-02-CRYPTSETUP

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -39,7 +39,6 @@ exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
 
 ## Integration test suite ##
 SKIP_LIST=(
-    "test/TEST-02-CRYPTSETUP" # flaky test (https://github.com/systemd/systemd/issues/10093)
     "test/TEST-10-ISSUE-2467" # https://github.com/systemd/systemd/pull/7494#discussion_r155635695
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
 )

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -39,7 +39,6 @@ exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
 
 ## Integration test suite ##
 SKIP_LIST=(
-    "test/TEST-02-CRYPTSETUP" # flaky test (https://github.com/systemd/systemd/issues/10093)
     "test/TEST-10-ISSUE-2467" # https://github.com/systemd/systemd/pull/7494#discussion_r155635695
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
 )


### PR DESCRIPTION
`test/TEST-02-CRYPTSETUP` was disabled in CentOS CI due to its flakiness (see systemd/systemd#10093). In efforts to make it stable once again, I went ahead and tried to reproduce the original issue, however, without any success. I ran the test ~200 times on a baremetal CentOS 7 machine and few dozen times in a QEMU Arch VM (inside of a Vagrant KVM VM), both on the latest master, and the test passed in all cases.

I'm not sure if the original issue was fixed indirectly by some upstream commit or if I've been extremely lucky so far, but I'd re-enable this test to see if the issue is indeed resolved or if it reappears again.