### PR TITLE
Re-enable systemd networkd tests

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -78,6 +78,9 @@ git_checkout_pr "$1"
 setenforce 0
 echo SELINUX=disabled >/etc/selinux/config
 
+# Disable firewalld (needed for systemd-networkd tests)
+systemctl disable firewalld
+
 # Compile systemd
 #   - slow-tests=true: enable slow tests => enables fuzzy tests using libasan
 #     installed above

--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -61,11 +61,10 @@ done
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"
-#    "test/test-network/systemd-networkd-tests.py"
 )
 
 for t in "${TEST_LIST[@]}"; do
-    exectask "$t" "${t##*/}.log" "./$t"
+    exectask "$t" "${t##*/}.log" "timeout 15m ./$t"
 done
 
 # Summary

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -72,11 +72,11 @@ done
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"
-#    "test/test-network/systemd-networkd-tests.py"
+    "test/test-network/systemd-networkd-tests.py"
 )
 
 for t in "${TEST_LIST[@]}"; do
-    exectask "$t" "${t##*/}.log" "./$t"
+    exectask "$t" "${t##*/}.log" "timeout 15m ./$t"
 done
 
 # Summary


### PR DESCRIPTION
Thanks to Yu's and Susant's efforts all known failures of the `systemd-networkd-tets.py` should be fixed. For now I'll re-enable it only for the "vanilla" CI (i.e. the baremetal CentOS 7), and if it remains stable I'd like to enable it in the Vagrant builds as well.