### PR TITLE
agent: re-enable test_exec_privatenetwork on RHEL8

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -33,8 +33,6 @@ set +e
 cd systemd
 
 # Run the internal unit tests (make check)
-# Temporarily disable test-exec-privatenetwork
-sed -i 's/test_exec_privatenetwork,//' src/test/test-execute.c
 exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
 
 ## Integration test suite ##


### PR DESCRIPTION
Should work since https://github.com/lnykryn/systemd-rhel/pull/288 was merged.