### PR TITLE
agent/rhel: cleanup loop devices after tests as well

### DIFF
--- a/agent/bootstrap-rhel7.sh
+++ b/agent/bootstrap-rhel7.sh
@@ -76,7 +76,7 @@ echo SELINUX=disabled >/etc/selinux/config
     # Disable nspawn version of the test
     export TEST_NO_NSPAWN=1
 
-    make -C test/TEST-01-BASIC clean setup run
+    make -C test/TEST-01-BASIC clean setup run clean
 ) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
 
 echo "-----------------------------"

--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -53,7 +53,7 @@ for t in test/TEST-??-*; do
     export QEMU_TIMEOUT=600
     export NSPAWN_TIMEOUT=600
 
-    exectask "$t" "${t##*/}.log" "make -C $t clean setup run"
+    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean"
     # Each integration test dumps the system journal when something breaks
     [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR/${t##*/}"
 done

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -61,7 +61,7 @@ for t in test/TEST-??-*; do
     export QEMU_TIMEOUT=600
     export NSPAWN_TIMEOUT=600
 
-    exectask "$t" "${t##*/}.log" "make -C $t clean setup run"
+    exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean"
     # Each integration test dumps the system journal when something breaks
     [ -d /var/tmp/systemd-test*/journal ] && rsync -aq /var/tmp/systemd-test*/journal "$LOGDIR/${t##*/}"
 done


### PR DESCRIPTION
Right now the 'clean' phase is called only before the test execution,
which leaves stray loop devices in the system and causes issues in
subsequent tests.