### PR TITLE
Revert "Temporary disable systemd-networkd-tests.py"

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -71,7 +71,7 @@ done
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"
-    #"test/test-network/systemd-networkd-tests.py"
+    "test/test-network/systemd-networkd-tests.py"
 )
 
 for t in "${TEST_LIST[@]}"; do


### PR DESCRIPTION
This reverts commit 98aabf61d64f6757bd88df4b4f0396c085ecd3e6.

Fixed by systemd/systemd#11741