### PR TITLE
Make test timeouts * 3

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -33,7 +33,7 @@ set +e
 cd systemd
 
 # Run the internal unit tests (make check)
-exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
+exectask "meson test (make check)" "ninja-test.log" "meson test -C build --timeout-multiplier=3"
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -33,7 +33,7 @@ set +e
 cd systemd
 
 # Run the internal unit tests (make check)
-exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
+exectask "meson test (make check)" "ninja-test.log" "meson test -C build --timeout-multiplier=3"
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -16,7 +16,7 @@ cd /build
 # Run the internal unit tests (make check)
 # Temporarily disable test-exec-privatenetwork
 sed -i 's/test_exec_privatenetwork,//' src/test/test-execute.c
-exectask "ninja test (make check)" "ninja-test.log" "ninja -C build test"
+exectask "meson test (make check)" "ninja-test.log" "meson test -C build --timeout-multiplier=3"
 
 ## Integration test suite ##
 SKIP_LIST=(


### PR DESCRIPTION
I added a new test in https://github.com/systemd/systemd/pull/11841,
and it runs in ~8s on my machine, ~17s with address sanitizer. But the
test fails on centos-ci after a 30s timeout.