### PR TITLE
vagrant: bump QEMU_TIMEOUT to 2000s

### DIFF
--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -36,7 +36,7 @@ for t in test/TEST-??-*; do
     ## Configure test environment
     # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
     # As we're not using KVM, bump the QEMU timeout quite a bit
-    export QEMU_TIMEOUT=1500
+    export QEMU_TIMEOUT=2000
     export NSPAWN_TIMEOUT=600
 
     exectask "$t" "${t##*/}.log" "make -C $t clean setup run clean-again"


### PR DESCRIPTION
TEST-24-UNIT-TESTS started failing intermittently due
to newly introduced fuzzers. Bump the QEMU timeout to
reflect this change.

---

Should `fix` https://github.com/systemd/systemd/pull/11887#issuecomment-469296378