### PR TITLE
vagrant: use 'clean-again' as the second cleanup phase

### DIFF
--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -47,7 +47,7 @@ for t in test/TEST-??-*; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask_p "${t##*/}" "make -C $t clean setup run clean"
+    exectask_p "${t##*/}" "make -C $t clean setup run clean-again"
 done
 
 # Wait for remaining running tasks


### PR DESCRIPTION
This correctly cleans artifacts after a successful test, so
the final artifacts are not cluttered by useless journals.