### PR TITLE
vagrant: enable systemd-networkd tests

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
         iptables kmod libcap libidn2 libgcrypt libmicrohttpd libxslt util-linux \
         linux-api-headers python-lxml quota-tools shadow gnu-efi-libs git meson \
         libseccomp pcre2 audit kexec-tools libxkbcommon bash-completion git ninja \
-        gcc m4 pkgconf
+        gcc m4 pkgconf ethtool
     # Install test dependencies
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -89,11 +89,11 @@ done
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"
-#    "test/test-network/systemd-networkd-tests.py"
+    "test/test-network/systemd-networkd-tests.py"
 )
 
 for t in "${TEST_LIST[@]}"; do
-    exectask "${t##*/}" "./$t"
+    exectask "${t##*/}" "timeout 30m ./$t"
 done
 
 # Summary


### PR DESCRIPTION
Let's try to enable `systemd-networkd-tests.py` under Vagrant (and more specifically under Arch), so we can test the new network-related features as well. 

After recent CI tweaks the test should be almost as fast as its baremetal counterpart, so hopefully it won't slow down the entire Vagrant job too much.