### PR TITLE
Lower the number of concurrent jobs

### DIFF
--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -14,12 +14,12 @@ declare -A TASK_QUEUE=()
 # utility. If that fails, fall back to using default values for necessary
 # variables.
 if NPROC=$(nproc); then
-    OPTIMAL_QEMU_SMP=2
-    MAX_QUEUE_SIZE=$((NPROC / OPTIMAL_QEMU_SMP))
-    if [[ $MAX_QUEUE_SIZE -lt 1 ]]; then
+    MAX_QUEUE_SIZE=3
+    OPTIMAL_QEMU_SMP=$((NPROC / MAX_QUEUE_SIZE))
+    if [[ $OPTIMAL_QEMU_SMP -lt 1 ]]; then
         # We have enough CPUs for only one concurrent task
-        OPTIMAL_QEMU_SMP=1
         MAX_QUEUE_SIZE=1
+        OPTIMAL_QEMU_SMP=1
     fi
 else
     # Using nproc failed, let's fall back to defaults, which can be overriden

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -23,7 +23,6 @@ SKIP_LIST=(
     "test/TEST-02-CRYPTSETUP" # flaky test (https://github.com/systemd/systemd/issues/10093)
     "test/TEST-10-ISSUE-2467" # https://github.com/systemd/systemd/pull/7494#discussion_r155635695
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
-    "test/TEST-25-IMPORT" # flaky test (https://github.com/systemd/systemd/issues/12039)
 )
 
 for t in test/TEST-??-*; do


### PR DESCRIPTION
The preparation/booting of the QEMU/nspawn machines is
pretty I/O heavy operation, which started causing some severe
timing issues in some cases. Let's limit the job queue to
three concurrent tasks, to somewhat mitigate this.

---

This should fix the fail in systemd/systemd#12039, as the `machinectl import` command was timeouting due to a heavy disk I/O.