### PR TITLE
common: initialize submodules when checking out a PR/commit

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -24,6 +24,9 @@ git_checkout_pr() {
         esac
     ) || return 1
 
+    # Initialize git submodules, if any
+    git submodule update --init --recursive
+
     echo -n "[git_checkout_pr] Checked out version: "
     git describe
 }


### PR DESCRIPTION
Let's support git submodules in the [systemd](https://github.com/systemd/systemd) repo.

Fixes #90 