### PR TITLE
common: fall back to head ref when merge ref doesn't exist

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -13,7 +13,14 @@ git_checkout_pr() {
     (set -e
         case $1 in
             pr:*)
-                git fetch -fu origin "refs/pull/${1#pr:}/merge:pr"
+                # Draft and already merged pull requests don't have the 'merge'
+                # ref anymore, so fall back to the *standard* 'head' ref in
+                # such cases and rebase it against the master branch
+                if ! git fetch -fu origin "refs/pull/${1#pr:}/merge:pr"; then
+                    git fetch -fu origin "refs/pull/${1#pr:}/head:pr"
+                    git rebase master pr
+                fi
+
                 git checkout pr
                 ;;
             "")


### PR DESCRIPTION
Let's fix cases when a **merge** ref doesn't exist, i.e. for already merged pull requests and draft pull requests. Fall back to the (hopefully) always present **head** ref in such cases.

Should fix cases like systemd/systemd#12265.