### PR TITLE
agent-control: ensure we have bash installed

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -357,7 +357,7 @@ if __name__ == "__main__":
 
         # Actual testing process
         logging.info("PHASE 1: Setting up basic dependencies to configure CI repository")
-        command = "yum -y install git && git clone {}{}".format(GITHUB_BASE, GITHUB_CI_REPO)
+        command = "yum -y install bash git && git clone {}{}".format(GITHUB_BASE, GITHUB_CI_REPO)
         ac.execute_remote_command(node, command)
 
         if args.ci_pr:


### PR DESCRIPTION
In several recent systemd runs I noticed a few fails due to missing `bash`. Even though it's a most likely an infrastructure *hiccup*, let's add a `bash` dependency as a precaution to reduce the false-negative job ratio.