### PR TITLE
agent-control: try to remove the git repo before cloning it

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -357,7 +357,8 @@ if __name__ == "__main__":
 
         # Actual testing process
         logging.info("PHASE 1: Setting up basic dependencies to configure CI repository")
-        command = "yum -y install bash git && git clone {}{}".format(GITHUB_BASE, GITHUB_CI_REPO)
+        command = "yum -y install bash git && rm -fr {} && git clone {}{}".format(GITHUB_CI_REPO,
+                  GITHUB_BASE, GITHUB_CI_REPO)
         ac.execute_remote_command(node, command)
 
         if args.ci_pr:

--- a/agent/bootstrap-rhel7.sh
+++ b/agent/bootstrap-rhel7.sh
@@ -34,8 +34,9 @@ git_checkout_pr "$1"
 # It's impossible to keep the local SELinux policy database up-to-date with
 # arbitrary pull request branches we're testing against.
 # Disable SELinux on the test hosts and avoid false positives.
-setenforce 0
-echo SELINUX=disabled >/etc/selinux/config
+if setenforce 0; then
+    echo SELINUX=disabled >/etc/selinux/config
+fi
 
 # Compile systemd
 (

--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -75,8 +75,9 @@ git_checkout_pr "$1"
 # It's impossible to keep the local SELinux policy database up-to-date with
 # arbitrary pull request branches we're testing against.
 # Disable SELinux on the test hosts and avoid false positives.
-setenforce 0
-echo SELINUX=disabled >/etc/selinux/config
+if setenforce 0; then
+    echo SELINUX=disabled >/etc/selinux/config
+fi
 
 # Compile systemd
 #   - slow-tests=true: enable slow tests => enables fuzzy tests using libasan

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -75,8 +75,9 @@ git_checkout_pr "$1"
 # It's impossible to keep the local SELinux policy database up-to-date with
 # arbitrary pull request branches we're testing against.
 # Disable SELinux on the test hosts and avoid false positives.
-setenforce 0
-echo SELINUX=disabled >/etc/selinux/config
+if setenforce 0; then
+    echo SELINUX=disabled >/etc/selinux/config
+fi
 
 # Disable firewalld (needed for systemd-networkd tests)
 systemctl disable firewalld


### PR DESCRIPTION
Followup to #94, as in some cases we might get a machine with a previously polluted multipath device mounted. We already do similar cleanups in other scripts, so let's do it here as well.