### PR TITLE
Call ninja test with --print-errorlogs for easier troubleshooting

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -33,7 +33,7 @@ set +e
 cd systemd
 
 # Run the internal unit tests (make check)
-exectask "ninja-test" "meson test -C build --timeout-multiplier=3"
+exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -33,7 +33,7 @@ set +e
 cd systemd
 
 # Run the internal unit tests (make check)
-exectask "ninja-test" "meson test -C build --timeout-multiplier=3"
+exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="$(dirname $0)"
 cd /build
 
 # Run the internal unit tests (make check)
-exectask "ninja-test" "meson test -C build --timeout-multiplier=3"
+exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 
 ## Integration test suite ##
 # Parallelized tasks


### PR DESCRIPTION
Let's show the first couple of errors from `ninja test` in the console log,
so one doesn't have to dig through the enormous meson testlog.txt file.