### PR TITLE
Run tests on Arch Linux under ASan & UBSan

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,55 @@
+# systemd CentOS CI under Vagrant
+
+As the *standard* CentOS CI tests systemd on CentOS 7, which is quite old (and allows
+us to test compatibility with older kernels), we need some way to do the opposite - i.e.
+test systemd with the newest packages. To achieve this, we use
+[Vagrant](https://www.vagrantup.com/) along with [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt)
+plugin to *easily* deploy libvirt VMs (with KVM acceleration) and run tests
+on [Arch Linux](https://www.archlinux.org/).
+
+The, so called, *pipeline* consists of following steps:
+
+1. `vagrant-ci-wrapper.sh`
+
+    This script is executed by our [Jenkins](https://jenkins.io/) job, and basically
+    prepares a local copy of the systemd [repository](https://github.com/systemd/systemd),
+    checks out a correct branch and executes the build script (see below) for
+    each distribution we have configured for Vagrant.
+
+    As Vagrant is not present in CentOS repositories, `vagrant-ci-wrapper.sh` also
+    makes use of `vagrant-setup.sh`, which downloads & installs the [upstream RPM](https://www.vagrantup.com/downloads.html)
+    provided by Vagrant, install libvirt & other dependencies, and compiles & installs
+    the vagrant-libvirt plugin.
+
+2. `vagrant-build.sh`
+
+    The Vagrant VM management is done by `vagrant-build.sh`, which locates the correct
+    Vagrantfile for provided distro tag, configures the environment appropriately,
+    spins up the VM, executes a test script according to the environment, and cleans up
+    the VM afterwards.
+
+    The compilation itself (along with installation of build & test dependencies)
+    is done during the VM provision phase using a provision script in a respective
+    Vagrantfile, as these steps are distro-specific and the CI scripts should be
+    (for the most part) distro-agnostic.
+
+    So far there are two tests scripts, for testing with and without sanitizers:
+
+    * `vagrant-test.sh`
+
+        Test systemd without sanitizers - do a reboot after installation and run unit tests,
+        fuzzers, and integration tests
+
+    * `vagrant-test-sanitizers.sh`
+
+        Test systemd with sanitizers ([Address Sanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) and
+        [Undefined Behavior Sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)).
+        As running under sanitizers has a huge performance impact, we skip machine reboot,
+        as this usually kills the machine or causes boot to timeout, and run only unit tests
+
+
+As we run the CI usually dozens of times per day, we'd have to update the packages
+in images each time (not counting the installation of build & test dependencies).
+To avoid this, and boost the runtime of the CI, we periodically execute `vagrant-make-cache.sh`
+which does these steps once in a few days, allowing us to reuse already up-to-date images
+in our CI runs without wasting time.

--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -85,7 +85,7 @@ Vagrant.configure("2") do |config|
           -Dslow-tests=true \
           -Dtests=unsafe \
           -Dinstall-tests=true \
-          -Ddbuspolicydir=/etc/dbus-1/system.d
+          -Ddbuspolicydir=/usr/share/dbus-1/system.d
     ninja -C build
     ninja -C build install
     popd

--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -85,9 +85,7 @@ Vagrant.configure("2") do |config|
           -Dslow-tests=true \
           -Dtests=unsafe \
           -Dinstall-tests=true \
-          -Ddbuspolicydir=/etc/dbus-1/system.d \
-          -Dnobody-user=nfsnobody \
-          -Dnobody-group=nfsnobody
+          -Ddbuspolicydir=/etc/dbus-1/system.d
     ninja -C build
     ninja -C build install
     popd

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
@@ -1,0 +1,96 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+  config.vm.define :archlinux_systemd_sanitizers
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
+  config.vm.box = "archlinux_systemd"
+  config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ENV["SYSTEMD_ROOT"], "/build"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Note: CentOS CI infra specific overrides - you may want to change them
+  #       to run the VM locally
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = if ENV["VAGRANT_DRIVER"] then ENV["VAGRANT_DRIVER"] else "kvm" end
+    libvirt.memory = if ENV["VAGRANT_MEMORY"] then ENV["VAGRANT_MEMORY"] else  "8192" end
+    libvirt.cpus = if ENV["VAGRANT_CPUS"] then ENV["VAGRANT_CPUS"] else 8 end
+
+    if ENV["VAGRANT_DISK_BUS"] then
+      libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
+    end
+  end
+
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    set -e
+
+    whoami
+
+    # The custom CentOS CI box should be updated and provide necessary
+    # build & test dependencies
+
+    # Use systemd repo path specified by SYSTEMD_ROOT
+    pushd /build
+
+    rm -fr build
+    # Build phase
+    # Compile systemd with the Address Sanitizer (ASan) and Undefined Behavior
+    # Sanitizer (UBSan)
+    CFLAGS='-g -O0 -ftrapv' meson build \
+          -Dtests=unsafe \
+          -Dinstall-tests=true \
+          -Ddbuspolicydir=/etc/dbus-1/system.d \
+          -Dnobody-user=nfsnobody \
+          -Dnobody-group=nfsnobody \
+          -Db_sanitize=address,undefined
+    ninja -C build
+    popd
+  SHELL
+end

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
@@ -87,8 +87,6 @@ Vagrant.configure("2") do |config|
           -Dtests=unsafe \
           -Dinstall-tests=true \
           -Ddbuspolicydir=/etc/dbus-1/system.d \
-          -Dnobody-user=nfsnobody \
-          -Dnobody-group=nfsnobody \
           -Db_sanitize=address,undefined
     ninja -C build
     popd

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
@@ -86,7 +86,7 @@ Vagrant.configure("2") do |config|
     CFLAGS='-g -O0 -ftrapv' meson build \
           -Dtests=unsafe \
           -Dinstall-tests=true \
-          -Ddbuspolicydir=/etc/dbus-1/system.d \
+          -Ddbuspolicydir=/usr/share/dbus-1/system.d \
           -Db_sanitize=address,undefined
     ninja -C build
     popd

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+# This script is part of the systemd Vagrant test suite for CentOS CI and
+# it's expected to be executed in a Vagrant VM configured by vagrant-build.sh
+# script.
+# Majority of this script is copied from the systemd-centos-ci/agent/testsuite.sh
+# script with some modifications to support other distributions. Test dependencies
+# for each distribution must be installed prior executing this script.
+
+DISTRO="${1:-unspecified}"
+SCRIPT_DIR="$(dirname $0)"
+# task-control.sh is copied from the systemd-centos-ci/common directory by vagrant-builder.sh
+. "$SCRIPT_DIR/task-control.sh" "vagrant-$DISTRO-testsuite" || exit 1
+
+cd /build
+
+# Sanitizer-specific options
+export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
+export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
+
+# Run the internal unit tests (make check)
+exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
+
+# Summary
+echo
+echo "TEST SUMMARY:"
+echo "-------------"
+echo "PASSED: $PASSED"
+echo "FAILED: $FAILED"
+echo "TOTAL:  $((PASSED + FAILED))"
+
+if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
+    echo
+    echo "FAILED TASKS:"
+    echo "-------------"
+    for task in "${FAILED_LIST[@]}"; do
+        echo "$task"
+    done
+fi
+
+[[ -d /build/build/meson-logs ]] && cp -r /build/build/meson-logs "$LOGDIR"
+exectask "journalctl-testsuite" "journalctl -b --no-pager"
+
+exit $FAILED


### PR DESCRIPTION
Let's experiment with ASan & UBSan on Arch. If it's feasible, make it part of our regular testing workflow, as Travis CI doesn't cover tests, which require a full-fledged VM.