### PR TITLE
vagrant: introduce Vagrant image/box cache

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -277,6 +277,33 @@ class AgentControl(object):
         # Give the node time to finish booting process
         time.sleep(30)
 
+    def upload_file(self, node, local_source, remote_target):
+        """Upload a file (or directory) to a remote host
+
+        Params:
+        -------
+        node : str
+            Hostname of the node
+        local_source : str
+            Path of a local (local) directory
+        remote_target : str
+            Path of a remote (target) directory
+
+        Returns:
+        --------
+        Return code of the underlying `scp` command
+        """
+        command = [
+            "/usr/bin/scp", "-r",
+            "-o UserKnownHostsFile=/dev/null",
+            "-o StrictHostKeyChecking=no",
+            local_source, "root@{}:{}".format(node, remote_target)
+        ]
+
+        logging.info("Uploading file {} to node {} as {}".format(local_source,
+                node, remote_target))
+
+        return self.execute_local_command(command)
 
 class SignalException(Exception):
     pass

--- a/agent-control.py
+++ b/agent-control.py
@@ -340,6 +340,8 @@ if __name__ == "__main__":
             help="Use RHEL downstream systemd repo")
     parser.add_argument("--vagrant", action="store_const", const=True,
             help="Run testing in Vagrant VMs")
+    parser.add_argument("--vagrant-sync", action="store_const", const=True,
+            help="Run a script which updates and rebuilds Vagrant images used by systemd CentOS CI")
     parser.add_argument("--version", default="7",
             help="CentOS version")
     args = parser.parse_args()
@@ -394,7 +396,13 @@ if __name__ == "__main__":
                       "git checkout pr".format(GITHUB_CI_REPO, args.ci_pr)
             ac.execute_remote_command(node, command)
 
-        if args.vagrant:
+        if args.vagrant_sync:
+            logging.info("PHASE 2: update & rebuild Vagrant images used by systemd CentOS CI")
+            # We need the duffy key to be able to upload to the CentOS CI artifact server
+            ac.upload_file(node, DUFFY_KEY_FILE, "/duffy.key")
+            command = "{}/vagrant/vagrant-make-cache.sh".format(GITHUB_CI_REPO)
+            ac.execute_remote_command(node, command)
+        elif args.vagrant:
             # Setup Vagrant and run the tests inside VM
             logging.info("PHASE 2: Run tests in Vagrant VMs")
             command = "{}/vagrant/vagrant-ci-wrapper.sh {}".format(GITHUB_CI_REPO, branch)

--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -9,14 +9,13 @@ Vagrant.configure("2") do |config|
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
-  config.vm.define :archlinux_systemd
+  config.vm.define :archlinux_systemd_ci
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  # Possible FIXME: archlinux/archlinux image is for some reason failing
-  # in the CentOS CI infrastructure due to unwritable keyring
-  # config.vm.box = "archlinux/archlinux"
-  config.vm.box = "generic/arch"
+  # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
+  config.vm.box = "archlinux_systemd"
+  config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -74,21 +73,8 @@ Vagrant.configure("2") do |config|
 
     whoami
 
-    # Initialize pacman's keyring
-    pacman-key --init
-    # Upgrade the system
-    pacman --noconfirm -Syu
-    # Install build dependencies
-    pacman --needed --noconfirm -S acl cryptsetup docbook-xsl gperf lz4 xz pam libelf intltool \
-        iptables kmod libcap libidn2 libgcrypt libmicrohttpd libxslt util-linux \
-        linux-api-headers python-lxml quota-tools shadow gnu-efi-libs git meson \
-        libseccomp pcre2 audit kexec-tools libxkbcommon bash-completion git ninja \
-        gcc m4 pkgconf
-    # Install test dependencies
-    # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
-    #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
-    pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
-        dnsmasq automake make dhclient rsync qemu socat
+    # The custom CentOS CI box should be updated and provide necessary
+    # build & test dependencies
 
     # Use systemd repo path specified by SYSTEMD_ROOT
     pushd /build

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -1,0 +1,64 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+  config.vm.define :archlinux_systemd
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  # Possible FIXME: archlinux/archlinux image is for some reason failing
+  # in the CentOS CI infrastructure due to unwritable keyring
+  # config.vm.box = "archlinux/archlinux"
+  config.vm.box = "generic/arch"
+  # Don't replace the original Vagrant's insecure key
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Note: CentOS CI infra specific overrides - you may want to change them
+  #       to run the VM locally
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = if ENV["VAGRANT_DRIVER"] then ENV["VAGRANT_DRIVER"] else "kvm" end
+    libvirt.memory = if ENV["VAGRANT_MEMORY"] then ENV["VAGRANT_MEMORY"] else  "8192" end
+    libvirt.cpus = if ENV["VAGRANT_CPUS"] then ENV["VAGRANT_CPUS"] else 8 end
+
+    if ENV["VAGRANT_DISK_BUS"] then
+      libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
+    end
+  end
+
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    set -e
+
+    whoami
+
+    # Initialize pacman's keyring
+    pacman-key --init
+    # Upgrade the system
+    pacman --noconfirm -Syu
+    # Install build dependencies
+    pacman --needed --noconfirm -S acl cryptsetup docbook-xsl gperf lz4 xz pam libelf intltool \
+        iptables kmod libcap libidn2 libgcrypt libmicrohttpd libxslt util-linux \
+        linux-api-headers python-lxml quota-tools shadow gnu-efi-libs git meson \
+        libseccomp pcre2 audit kexec-tools libxkbcommon bash-completion git ninja \
+        gcc m4 pkgconf
+    # Install test dependencies
+    # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
+    #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
+    pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
+        dnsmasq automake make dhclient rsync qemu socat
+  SHELL
+end

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Relatively simple script which updates Vagrant boxes used by systemd CentOS CI
+# with build dependencies and other configuration, so we don't have to that in
+# every CI job. These updated images are then stored on the CentOS CI artifact
+# server and can be reused by other CI jobs.
+# This script is intended to run in CentOS CI Jenkins periodically, to keep
+# the images up-to-date.
+#
+# In time of writing this, the setup phase, which consists of updating the
+# base system in the container and installing build/test dependencies, took
+# around 10 minutes, which is pretty substantial time slice for a CI run, which
+# takes ~45 minutes.
+
+set -eu
+set -o pipefail
+
+EC=0
+# CentOS CI specific thing - a part of the duffy key is necessary to
+# authenticate against the CentOS CI rsync server
+DUFFY_KEY_FILE="/duffy.key"
+VAGRANT_ROOT="$(dirname $(readlink -f $0))"
+# Relative paths to cache-able Vagrantfiles
+VAGRANTFILES=(
+    $VAGRANT_ROOT/boxes/Vagrantfile_archlinux_systemd
+)
+
+# Install vagrant if not already installed
+$VAGRANT_ROOT/vagrant-setup.sh
+
+# Stop firewalld
+systemctl stop firewalld
+systemctl restart libvirtd
+
+for vagrantfile in "${VAGRANTFILES[@]}"; do
+    TEMP_DIR="$(mktemp -d vagrant-cache-XXXXX)"
+    pushd "$TEMP_DIR"
+
+    # Start a VM described in the Vagrantfile with all provision steps
+    export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
+    export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
+    export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
+    export VAGRANT_DISK_BUS
+
+    cp "$vagrantfile" Vagrantfile
+    vagrant up --provider=libvirt
+
+    # Run the following commands in a subshell, so we can do a proper cleanup
+    # even in case of an error
+    set +e
+    (
+        vagrant halt
+        # Create a box from the VM, so it can be reused later
+        # Output file example:
+        #   boxes/Vagrantfile_archlinux_systemd => archlinux_systemd
+        BOX_NAME="${vagrantfile##*/Vagrantfile_}"
+        # Workaround for `virt-sysprep` - work with the image via qemu directly
+        # instead of using libvirt
+        export LIBGUESTFS_BACKEND=direct
+        # Another, pretty ugly, workaround for `vagrant package`, where the
+        # embedded `virt-sysprep` strips away vagrant's ssh keys and makes
+        # any new images based on such box unusable for our purposes.
+        # The temporary fix is taken from
+        #   https://github.com/vagrant-libvirt/vagrant-libvirt/issues/759#issuecomment-293585359
+        # a better fix is already merged in the master of vagrant-libvirt, but
+        # not yet released:
+        #   https://github.com/vagrant-libvirt/vagrant-libvirt/pull/955
+        # Note: this is only half of the workaround, the second half is in the
+        # 'box' Vagrantfile, where the original Vagrant SSH key is not replaced
+        # by a more secure one (option config.ssh.insert_key=false).
+        # That's also necessary, as described here:
+        #   https://github.com/vagrant-libvirt/vagrant-libvirt/issues/759#issuecomment-432200391
+        # I'm slowly starting to question my choices
+        sed -i'' 's/virt-sysprep --no-logfile.*$/virt-sysprep --no-logfile --operations defaults,-ssh-userdir,-ssh-hostkeys -a #{@tmp_img}`/' $(find ~/.vagrant.d/ -name package_domain.rb)
+        # You guessed it, another workaround - let's include the original
+        # Vagrantfile as well, as it usually contains important settings
+        # which make the box actually bootable. For this, we need to detect the location
+        # of the box, from the original box name (i.e. generic/arch, see the
+        # beautiful awk below), and then transform it to a path to the Vagrantfile,
+        # which contains the box name, but all slashes are replaced by
+        # "-VAGRANTSLASH-" (and that's what the bash substitution is for)
+        ORIGINAL_BOX_NAME="$(awk 'match($0, /^[^#]*config.vm.box\s*=\s*"([^"]+)"/, m) { print m[1]; exit 0; }' "$vagrantfile")"
+        vagrant package --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/${ORIGINAL_BOX_NAME//\//-VAGRANTSLASH-}/*/libvirt/Vagrantfile
+
+        # Upload the box to the CentOS CI artifact storage
+        # CentOS CI rsync password is the first 13 characters of the duffy key
+        PASSWORD_FILE="$(mktemp .rsync-passwd.XXX)"
+        cut -b-13 "$DUFFY_KEY_FILE" > "$PASSWORD_FILE"
+
+        # Little workaround to create a proper directory hierarchy on the server
+        mkdir vagrant_boxes
+        mv "$BOX_NAME" vagrant_boxes
+
+        rsync --password-file="$PASSWORD_FILE" -av "vagrant_boxes" systemd@artifacts.ci.centos.org::systemd/
+        echo "Box URL: http://artifacts.ci.centos.org/systemd/vagrant_boxes/$BOX_NAME"
+    )
+
+    if [[ $? -ne 0 ]]; then
+        EC=1
+    fi
+
+    # Cleanup
+    vagrant destroy -f
+    rm -fr "$TEMP_DIR"
+    popd
+    set -e
+done
+
+exit $EC

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -13,7 +13,7 @@ if ! vagrant version 2>/dev/null; then
     # Install Vagrant
     yum -y install "$VAGRANT_PKG_URL"
     # Install vagrant-libvirt dependencies
-    yum -y install qemu libvirt libvirt-devel ruby-devel gcc qemu-kvm
+    yum -y install qemu libvirt libvirt-devel ruby-devel gcc qemu-kvm libguestfs-tools-c
     # Start libvirt daemon
     systemctl start libvirtd
     systemctl status libvirtd


### PR DESCRIPTION
Let's update, rebuild, and cache Vagrant images, which we use in systemd CentOS CI.

This should have a pretty substantial performance impact, as the *setup* phase, which involves updating the base system & installing test and build dependencies usually takes ~10 minutes.