### PR TITLE
tree-wide: generate man pages by default

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -140,6 +140,8 @@ fi
             -Dinstall-tests=true
             -Dc_args='-g -O0 -ftrapv'
             --werror
+            -Dman=true
+            -Dhtml=true
     )
     meson build "${CONFIGURE_OPTS[@]}"
     ninja-build -C build

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -95,7 +95,9 @@ systemctl disable firewalld
                 -Dinstall-tests=true \
                 -Ddbuspolicydir=/etc/dbus-1/system.d \
                 -Dnobody-user=nfsnobody \
-                -Dnobody-group=nfsnobody
+                -Dnobody-group=nfsnobody \
+                -Dman=true \
+                -Dhtml=true
     ninja-build -C build
 ) 2>&1 | tee "$LOGDIR/build.log"
 

--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -87,7 +87,9 @@ Vagrant.configure("2") do |config|
           -Dslow-tests=true \
           -Dtests=unsafe \
           -Dinstall-tests=true \
-          -Ddbuspolicydir=/usr/share/dbus-1/system.d
+          -Ddbuspolicydir=/usr/share/dbus-1/system.d \
+          -Dman=true \
+          -Dhtml=true
     ninja -C build
     ninja -C build install
     popd

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers
@@ -89,6 +89,8 @@ Vagrant.configure("2") do |config|
           -Dtests=unsafe \
           -Dinstall-tests=true \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \
+          -Dman=true \
+          -Dhtml=true \
           -Db_sanitize=address,undefined
     ninja -C build
     popd


### PR DESCRIPTION
When systemd/systemd#12519 gets merged, man pages will be built on-demand
only. Let's enable the man page generation explicitly, so we can test it
even after this change.
