### PR TITLE
common: show commit description after checkout

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -37,4 +37,5 @@ git_checkout_pr() {
 
     echo -n "[$FUNCNAME] Checked out version: "
     git describe
+    git log -1
 }


### PR DESCRIPTION
As `git describe` generates a particularly useless tag (which points to
a merge commit provided by the `merge` ref), let's dump the object
description as well, which includes top commits of both the PR and
target branches. This should give us a better idea what was actually
tested

---

Should help in situations like https://github.com/systemd/systemd/pull/12577#issuecomment-493582200