### PR TITLE
vagrant: bump the nspawn timeout to 15 minutes

### DIFF
--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -34,7 +34,7 @@ for t in test/TEST-??-*; do
     # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
     # As we're not using KVM, bump the QEMU timeout quite a bit
     export QEMU_TIMEOUT=2000
-    export NSPAWN_TIMEOUT=600
+    export NSPAWN_TIMEOUT=900
     # Set the test dir to something predictable so we can refer to it later
     export TESTDIR="/var/tmp/systemd-test-${t##*/}"
     # Set QEMU_SMP appropriately (regarding the parallelism)


### PR DESCRIPTION
The amount of unit tests in TEST-24-UNIT-TESTS rises slowly, but
steadily, and it started triggering the 10m timeout in systemd-nspawn.
Let's bump it to 15m

cc @yuwata 