### PR TITLE
vagrant: install wireguard-arch package

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -59,6 +59,6 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
-        dnsmasq automake make dhclient rsync qemu socat
+        dnsmasq automake make dhclient rsync qemu socat wireguard-arch
   SHELL
 end


### PR DESCRIPTION
This should allow us to run wireguard tests from the systemd-networkd
testsuite

Fixes #122