### PR TITLE
debug-only: udev debug

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -146,6 +146,7 @@ fi
 
 # Set user_namespace.enable=1 (needed for systemd-nspawn -U to work correctly)
 grubby --args="user_namespace.enable=1" --update-kernel="$(grubby --default-kernel)"
+grubby --args="udev.log_priority=debug" --update-kernel="$(grubby --default-kernel)"
 grep "user_namespace.enable=1" /boot/grub2/grub.cfg
 echo "user.max_user_namespaces=10000" >> /etc/sysctl.conf
 

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -11,6 +11,9 @@ SCRIPT_DIR="$(dirname $0)"
 # task-control.sh is copied from the systemd-centos-ci/common directory by vagrant-builder.sh
 . "$SCRIPT_DIR/task-control.sh" "vagrant-$DISTRO-testsuite" || exit 1
 
+ls -la /usr/lib/systemd/network
+cat /usr/lib/systemd/network/99-default.link
+
 cd /build
 
 # Run the internal unit tests (make check)


### PR DESCRIPTION
Let's attempt to run systemd/systemd#12700 with `udev.log_priority=debug` (CentOS CI) and systemd/systemd#12708 with a simple find to locate `99-default.link` (CentOS CI - Arch in KVM).

I really need to make this configurable per-PR.

