### PR TITLE
Introduce pre/post tasks

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -72,6 +72,10 @@ pushd systemd
 
 git_checkout_pr "${1:-""}"
 
+# If a pre-bootstrap script exists in the root of the systemd repo, source it
+test -e .centosci-pre-bootstrap && source .centosci-pre-bootstrap
+
+MESON_ARGS="${MESON_ARGS:-""}"
 # It's impossible to keep the local SELinux policy database up-to-date with
 # arbitrary pull request branches we're testing against.
 # Disable SELinux on the test hosts and avoid false positives.
@@ -97,7 +101,7 @@ systemctl disable firewalld
                 -Dnobody-user=nfsnobody \
                 -Dnobody-group=nfsnobody \
                 -Dman=true \
-                -Dhtml=true
+                -Dhtml=true $MESON_ARGS
     ninja-build -C build
 ) 2>&1 | tee "$LOGDIR/build.log"
 
@@ -148,6 +152,9 @@ fi
 grubby --args="user_namespace.enable=1" --update-kernel="$(grubby --default-kernel)"
 grep "user_namespace.enable=1" /boot/grub2/grub.cfg
 echo "user.max_user_namespaces=10000" >> /etc/sysctl.conf
+
+# If a post-bootstrap script exists in the root of the systemd repo, source it
+test -e .centosci-post-bootstrap && source .centosci-post-bootstrap
 
 echo "-----------------------------"
 echo "- REBOOT THE MACHINE BEFORE -"

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,28 @@
+# systemd CentOS CI debugging
+
+If the systemd CentOS CI job is failing for your systemd PR, it may become
+difficult to debug the root cause without proper logs, in some cases.
+To make this somewhat easier without creating a separate PR in the systemd
+CentOS CI repo and then pointing it to your systemd PR, you can make use of so
+called *pre* and *post* tasks for each CI phase.
+
+For the standard CentOS CI runs (i.e. the **CentOS 7 job**) this means you have
+pre/post tasks for the *bootstrap* and *testsuite* phase. All these task scripts
+have to exist in the root of the systemd repository to be taken into consideration.
+
+- `.centosci-pre-bootstrap`
+  executed right after the systemd repository is cloned and checked out into
+  the respective PR branch; can be used to tweak the systemd compilation by
+  adding additional meson arguments via `MESON_ARGS` variable
+
+- `.centosci-post-bootstrap`
+  executed right before systemd reboot, i.e. after everything is compiled and
+  installed; can be used to tweak kernel arguments and other configuration
+
+- `.centosci-pre-testsuite`
+  executed after installing test dependencies and before running any tests
+
+- `.centosci-post-testsuite`
+  executed after running all tests
+
+TBD


### PR DESCRIPTION
After recent @yuwata's struggles with getting proper debug logs for certain PRs without too much hassle, I tried to introduce a concept of pre and post tasks. Basically, they should allow you to tweak the build environment before and after each phase to make the debugging much easier without creating any additional PRs in this repository and trying to point the Jenkins job to the right place.

To better explain how this should all work, I wrote a short documentation draft. If this all makes sense, I'll do something similar to the Vagrant jobs as well.

cc @evverx 