### PR TITLE
agent: correctly collect meson logs

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -10,7 +10,6 @@ REPO_URL="${REPO_URL:-https://github.com/systemd-rhel/rhel-8.git}"
 function at_exit {
     # Let's collect some build-related logs
     set +e
-    [[ -d systemd/build/meson-logs ]] && cp -r systemd/build/meson-logs "$LOGDIR"
     rsync -amq /var/tmp/systemd-test*/journal "$LOGDIR" &>/dev/null || :
     exectask "journalctl-bootstrap" "journalctl -b --no-pager"
 }
@@ -85,6 +84,8 @@ fi
 #   - tests=unsafe: enable unsafe tests, which might change the environment
 #   - install-tests=true: necessary for test/TEST-24-UNIT-TESTS
 (
+    # Make sure we copy over the meson logs even if the compilation fails
+    trap "[[ -d $PWD/build/meson-logs ]] && cp -r $PWD/build/meson-logs '$LOGDIR'" EXIT
     CONFIGURE_OPTS=(
             # RHEL8 options
             -Dsysvinit-path=/etc/rc.d/init.d

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -10,7 +10,6 @@ REPO_URL="${REPO_URL:-https://github.com/systemd/systemd.git}"
 function at_exit {
     # Let's collect some build-related logs
     set +e
-    [[ -d systemd/build/meson-logs ]] && cp -r systemd/build/meson-logs "$LOGDIR"
     rsync -amq /var/tmp/systemd-test*/journal "$LOGDIR" &>/dev/null || :
     exectask "journalctl-bootstrap" "journalctl -b --no-pager"
 }
@@ -88,6 +87,8 @@ systemctl disable firewalld
 #   - tests=unsafe: enable unsafe tests, which might change the environment
 #   - install-tests=true: necessary for test/TEST-24-UNIT-TESTS
 (
+    # Make sure we copy over the meson logs even if the compilation fails
+    trap "[[ -d $PWD/build/meson-logs ]] && cp -r $PWD/build/meson-logs '$LOGDIR'" EXIT
     meson build -Dc_args='-g -O0 -ftrapv' \
                 --werror \
                 -Dslow-tests=true \


### PR DESCRIPTION
Originally, the meson logs were collected in the final EXIT handler with
the rest of the logs. However, as we use a relative path for them and we
change the CWD multiple times throughout the bootstrap process, the
relative path may become invalid (and it indeed does) during error
handling. Let's register a separate EXIT handler for this with an
absolute path, so we get the meson logs in all cases