### PR TITLE
vagrant: run slow tests under sanitizers

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -93,6 +93,7 @@ Vagrant.configure("2") do |config|
           --werror \
           -Dc_args='-g -O0 -ftrapv' \
           -Dtests=unsafe \
+          -Dslow-tests=true \
           -Dinstall-tests=true \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \
           -Dman=false \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -87,6 +87,7 @@ Vagrant.configure("2") do |config|
           --werror \
           -Dc_args='-g -O0 -ftrapv' \
           -Dtests=unsafe \
+          -Dslow-tests=true \
           -Dinstall-tests=true \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \
           -Dman=false \

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -25,7 +25,7 @@ if _clang_asan_rt_name="$(ldd build/systemd | awk '/libclang_rt.asan/ {print $1;
 fi
 
 # Run the internal unit tests (make check)
-exectask "ninja-test_sanitizers" "meson test -C build --print-errorlogs --timeout-multiplier=3"
+exectask "ninja-test_sanitizers" "meson test -C build --print-errorlogs --timeout-multiplier=10"
 
 ## Run TEST-01-BASIC under test sanitizers
 # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck


### PR DESCRIPTION
Another attempt in running the slow tests (`-Dslow-tests=true`) under ASan & UBSan. Let's see what else is broken (if anything) since https://github.com/systemd/systemd/pull/12824 was merged.