### PR TITLE
vagrant: temporarily disable detect_stack_use_after_return for gcc9

### DIFF
--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -14,7 +14,13 @@ SCRIPT_DIR="$(dirname $0)"
 pushd /build || (echo >&2 "Can't pushd to /build"; exit 1)
 
 # Sanitizer-specific options
-export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
+if ldd build/systemd | grep -q libasan; then
+# Temporarily disable the detect_stack_use_after_return runtime option due
+# to performance issues with GCC9
+    export ASAN_OPTIONS=strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=0
+else
+    export ASAN_OPTIONS=strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1
+fi
 export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
 
 if _clang_asan_rt_name="$(ldd build/systemd | awk '/libclang_rt.asan/ {print $1; exit}')"; then
@@ -23,6 +29,8 @@ if _clang_asan_rt_name="$(ldd build/systemd | awk '/libclang_rt.asan/ {print $1;
     _clang_asan_rt_path="$(find /usr/lib* /usr/local/lib* -type f -name "$_clang_asan_rt_name" 2>/dev/null | sed 1q)"
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${_clang_asan_rt_path%/*}"
 fi
+
+declare -p ASAN_OPTIONS UBSAN_OPTIONS LD_LIBRARY_PATH
 
 # Run the internal unit tests (make check)
 exectask "ninja-test_sanitizers" "meson test -C build --print-errorlogs --timeout-multiplier=3"
@@ -38,20 +46,25 @@ export QEMU_SMP=$(nproc)
 # are compiled in as modules
 export SKIP_INITRD=no
 
-# 1) Run it under systemd-nspawn
-rm -fr /var/tmp/systemd-test*
-exectask "TEST-01-BASIC_sanitizers-nspawn" "make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_QEMU=1"
-NSPAWN_EC=$?
-# Each integration test dumps the system journal when something breaks
-rsync -amq /var/tmp/systemd-test*/journal "$LOGDIR/TEST-01-BASIC_sanitizers-nspawn/" &>/dev/null || :
-
-if [[ $NSPAWN_EC -eq 0 ]]; then
-    # 2) Run it under QEMU, but only if the systemd-nspawn run was successful
+# Skip the basic integration tests on gcc as well (see above), as we can't
+# override the ASAN_OPTIONS from the outside (see create_asan_wrapper under
+# systemd/test/test-functions)
+if ! ldd build/systemd | grep -q libasan; then
+    # 1) Run it under systemd-nspawn
     rm -fr /var/tmp/systemd-test*
-    exectask "TEST-01-BASIC_sanitizers-qemu" "make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1"
-    #make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1 KERNEL_APPEND=debug
+    exectask "TEST-01-BASIC_sanitizers-nspawn" "make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_QEMU=1"
+    NSPAWN_EC=$?
     # Each integration test dumps the system journal when something breaks
-    rsync -amq /var/tmp/systemd-test*/journal "$LOGDIR/TEST-01-BASIC_sanitizers-qemu/" &>/dev/null || :
+    rsync -amq /var/tmp/systemd-test*/journal "$LOGDIR/TEST-01-BASIC_sanitizers-nspawn/" &>/dev/null || :
+
+    if [[ $NSPAWN_EC -eq 0 ]]; then
+        # 2) Run it under QEMU, but only if the systemd-nspawn run was successful
+        rm -fr /var/tmp/systemd-test*
+        exectask "TEST-01-BASIC_sanitizers-qemu" "make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1"
+        #make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_NSPAWN=1 KERNEL_APPEND=debug
+        # Each integration test dumps the system journal when something breaks
+        rsync -amq /var/tmp/systemd-test*/journal "$LOGDIR/TEST-01-BASIC_sanitizers-qemu/" &>/dev/null || :
+    fi
 fi
 
 # Summary


### PR DESCRIPTION
With gcc9 the detect_stack_use_after_return introduces a severe
performance overhead causing timing issues in the testsuite. Let's
disable it (only for gcc run) until a proper solution is found

See systemd/systemd#12856