### PR TITLE
common: extract encountered sanitizer errors

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -46,12 +46,14 @@ git_checkout_pr() {
 check_for_sanitizer_errors() {
     awk '
     BEGIN {
+        # Counters
         asan_cnt = 0;
         ubsan_cnt = 0;
         msan_cnt = 0;
         total_cnt = 0;
     }
 
+    # Counters
     match($0, /SUMMARY:\s+(\w+)Sanitizer/, m) {
         total_cnt++;
 
@@ -66,6 +68,15 @@ check_for_sanitizer_errors() {
             msan_cnt++;
             break;
         }
+
+        # Print a newline after every SUMMARY line (i.e. end of the sanitizer error
+        # block), to improve readability
+        print "\n";
+    }
+
+    # Extractors
+    /([0-9]+: runtime error|==[0-9]+==.+?\w+Sanitizer)/,/SUMMARY:\s+(\w+)Sanitizer/ {
+        print $0;
     }
 
     END {


### PR DESCRIPTION
This should cover https://github.com/systemd/systemd/pull/12904#issuecomment-506778965, or at least a part of it, as adding the filename would be somewhat cumbersome (especially for the journal, as it's generated in the `EXIT` handler).

Some examples:

```
$ curl -q https://ci.centos.org/job/systemd-pr-build-vagrant-sanitizers/928/artifact//systemd-centos-ci/artifacts_all/artifacts_HziRYX/vagrant-logs.MZE/vagrant-arch-sanitizers-gcc-testsuite.Q5G/systemd-networkd_sanitizers_FAIL.log | check_for_sanitizer_errors
                             
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0test_glob (__main__.NetworkctlTests) ... ../src/shared/linux/ethtool.h:129:23: runtime error: left shift of 65535 by 16 places cannot be represented in type 'int'
    #0 0x7f1adf7e36c0 in ethtool_cmd_speed ../src/shared/linux/ethtool.h:129
    #1 0x7f1adf7e5382 in ethtool_get_link_info ../src/shared/ethtool-util.c:207
    #2 0x564e403c197f in acquire_link_info ../src/network/networkctl.c:290
    #3 0x564e403c2167 in list_links ../src/network/networkctl.c:321
    #4 0x7f1adf8f00e9 in dispatch_verb ../src/shared/verbs.c:113
    #5 0x564e403d3b3f in networkctl_main ../src/network/networkctl.c:1713
    #6 0x564e403d3c1b in run ../src/network/networkctl.c:1737
    #7 0x564e403d3c4e in main ../src/network/networkctl.c:1740
    #8 0x7f1ade325ce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)
    #9 0x564e403bdbed in _start (/build/build/networkctl+0x24bed)
                                                                       
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/shared/linux/ethtool.h:129:23 in
         
                                      
../src/shared/linux/ethtool.h:129:23: runtime error: left shift of 65535 by 16 places cannot be represented in type 'int'
    #0 0x7f3c39f206c0 in ethtool_cmd_speed ../src/shared/linux/ethtool.h:129
    #1 0x7f3c39f22382 in ethtool_get_link_info ../src/shared/ethtool-util.c:207
    #2 0x56534ccff97f in acquire_link_info ../src/network/networkctl.c:290
    #3 0x56534cd0e54d in link_status ../src/network/networkctl.c:1360 
    #4 0x7f3c3a02d0e9 in dispatch_verb ../src/shared/verbs.c:113
    #5 0x56534cd11b3f in networkctl_main ../src/network/networkctl.c:1713
    #6 0x56534cd11c1b in run ../src/network/networkctl.c:1737
    #7 0x56534cd11c4e in main ../src/network/networkctl.c:1740
    #8 0x7f3c38a62ce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)
    #9 0x56534ccfbbed in _start (/build/build/networkctl+0x24bed)
                                      
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/shared/linux/ethtool.h:129:23 in
                                                                                                                                                                                                                                                                                                                                                                                              
                                                                     
 57  193k   57  111k    0     0   113k      0  0:00:01 --:--:--  0:00:01  113ktest_lldp (__main__.NetworkdLLDPTests) ... ../src/shared/linux/ethtool.h:129:23: runtime error: left shift of 65535 by 16 places cannot be represented in type 'int'
    #0 0x7faf4099f6c0 in ethtool_cmd_speed ../src/shared/linux/ethtool.h:129
    #1 0x7faf409a1382 in ethtool_get_link_info ../src/shared/ethtool-util.c:207                                                                                                                                                                                                                                                                                                               
    #2 0x559f2234b97f in acquire_link_info ../src/network/networkctl.c:290
    #3 0x559f2235b1f2 in link_lldp_status ../src/network/networkctl.c:1436
    #4 0x7faf40aac0e9 in dispatch_verb ../src/shared/verbs.c:113
    #5 0x559f2235db3f in networkctl_main ../src/network/networkctl.c:1713
    #6 0x559f2235dc1b in run ../src/network/networkctl.c:1737                                                                                                                                                                                                                                                                                                                                 
    #7 0x559f2235dc4e in main ../src/network/networkctl.c:1740
    #8 0x7faf3f4e1ce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)          
    #9 0x559f22347bed in _start (/build/build/networkctl+0x24bed)            
                                                                                                                                                                                                                                                                                                                                                                                              
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/shared/linux/ethtool.h:129:23 in
                                                                               
                                                                          
100  193k  100  193k    0     0   185k      0  0:00:01  0:00:01 --:--:--  185k
 ____________________________________________                   
/ Found   3 sanitizer errors (  0 ASan,   3  \                           
| UBSan,   0 MSan). Looks like you need to   |               
\ look at the log                            /                
 --------------------------------------------                        
 \                                                               
  \
     __                                                                                        
    /  \
    |  |
    @  @                                                                                                                 
    |  |                                                                    
    || |/                                                                      
    || ||                                                                 
    |\_/|                                                            
    \___/   
```

```
$ curl -q https://ci.centos.org/job/systemd-pr-build-vagrant-sanitizers/928/artifact//systemd-centos-ci/artifacts_all/artifacts_HziRYX/vagrant-logs.MZE/vagrant-arch-sanitizers-gcc-testsuite.Q5G/journalctl-testsuite_PASS.log | check_for_sanitizer_errors
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                   
                                 Dload  Upload   Total   Spent    Left  Speed                                                                                                                 
  8 4232k    8  351k    0     0   274k      0  0:00:15  0:00:01  0:00:14  274kJun 28 06:25:48 arch.localdomain systemd-networkd[2290]: ==2290==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x613000001694 at pc 0x7f1a32265ee1 bp 0x7fff7a67baa0 sp 0x7fff7a67b248
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]: READ of size 32 at 0x613000001694 thread T0                                                        
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #0 0x7f1a32265ee0 in __interceptor_strndup /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:326
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #1 0x562f26466c57 in lease_parse_string ../src/libsystemd-network/sd-dhcp-lease.c:336     
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #2 0x562f26466ecb in lease_parse_domain ../src/libsystemd-network/sd-dhcp-lease.c:353          
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #3 0x562f26469e0f in dhcp_lease_parse_options ../src/libsystemd-network/sd-dhcp-lease.c:591
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #4 0x562f2645f63a in parse_options ../src/libsystemd-network/dhcp-option.c:223            
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #5 0x562f2645f91a in dhcp_option_parse ../src/libsystemd-network/dhcp-option.c:251             
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #6 0x562f2643b346 in client_handle_offer ../src/libsystemd-network/sd-dhcp-client.c:1339
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #7 0x562f26441d10 in client_handle_message ../src/libsystemd-network/sd-dhcp-client.c:1616
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #8 0x562f264454d1 in client_receive_message_raw ../src/libsystemd-network/sd-dhcp-client.c:1882
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #9 0x7f1a31677e62 in source_dispatch ../src/libsystemd/sd-event/sd-event.c:2827
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #10 0x7f1a3167e5dd in sd_event_dispatch ../src/libsystemd/sd-event/sd-event.c:3240                    
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #11 0x7f1a3167f572 in sd_event_run ../src/libsystemd/sd-event/sd-event.c:3297                  
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #12 0x7f1a3167f89f in sd_event_loop ../src/libsystemd/sd-event/sd-event.c:3319 
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #13 0x562f2629c978 in run ../src/network/networkd.c:114                                               
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #14 0x562f2629cb8f in main ../src/network/networkd.c:121                                       
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #15 0x7f1a2fd37ce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)             
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #16 0x562f2629ac6d in _start (/build/build/systemd-networkd+0x2ccc6d)                                                                                                                                                                                                                                                            
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]: 0x613000001694 is located 0 bytes to the right of 340-byte region [0x613000001540,0x613000001694)  
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]: allocated by thread T0 here:                                                       
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #0 0x7f1a3229d5a1 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:95                                                                                                                                                                                                                           
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #1 0x562f26444c77 in client_receive_message_raw ../src/libsystemd-network/sd-dhcp-client.c:1850
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #2 0x7f1a31677e62 in source_dispatch ../src/libsystemd/sd-event/sd-event.c:2827
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #3 0x7f1a3167e5dd in sd_event_dispatch ../src/libsystemd/sd-event/sd-event.c:3240                                                                                                                                                                                                                                                
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #4 0x7f1a3167f572 in sd_event_run ../src/libsystemd/sd-event/sd-event.c:3297
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #5 0x7f1a3167f89f in sd_event_loop ../src/libsystemd/sd-event/sd-event.c:3319                                                    
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #6 0x562f2629c978 in run ../src/network/networkd.c:114                                                                                                     
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #7 0x562f2629cb8f in main ../src/network/networkd.c:121                              
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]:     #8 0x7f1a2fd37ce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)                                                                
Jun 28 06:25:48 arch.localdomain systemd-networkd[2290]: SUMMARY: AddressSanitizer: heap-buffer-overflow /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:326 in __interceptor_strndup   

<..snip...>
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]: ==3942==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x612000000a77 at pc 0x7f3e964e9ee1 bp 0x7ffc0456a6e0 sp 0x7ffc04569e88                                                                               
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]: READ of size 21 at 0x612000000a77 thread T0
Jun 28 06:40:01 arch.localdomain systemd-networkd-wait-online[3945]: veth-peer: link is being processed by networkd
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #0 0x7f3e964e9ee0 in __interceptor_strndup /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:326                                                                                  
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #1 0x562922219c57 in lease_parse_string ../src/libsystemd-network/sd-dhcp-lease.c:336                                                                                                                              
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #2 0x56292221d62b in dhcp_lease_parse_options ../src/libsystemd-network/sd-dhcp-lease.c:630                                                                                                                        
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #3 0x56292221263a in parse_options ../src/libsystemd-network/dhcp-option.c:223                                                                                                                                     
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #4 0x56292221291a in dhcp_option_parse ../src/libsystemd-network/dhcp-option.c:251                                                                                                                                 
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #5 0x5629221ef90e in client_handle_ack ../src/libsystemd-network/sd-dhcp-client.c:1422                                                                                                                             
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #6 0x5629221f5073 in client_handle_message ../src/libsystemd-network/sd-dhcp-client.c:1640                                                                                                                         
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #7 0x5629221f84d1 in client_receive_message_raw ../src/libsystemd-network/sd-dhcp-client.c:1882                                                                                                                    
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #8 0x7f3e958fbe62 in source_dispatch ../src/libsystemd/sd-event/sd-event.c:2827                                                                                                                                    
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #9 0x7f3e959025dd in sd_event_dispatch ../src/libsystemd/sd-event/sd-event.c:3240                                                                                                                                  
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #10 0x7f3e95903572 in sd_event_run ../src/libsystemd/sd-event/sd-event.c:3297                                                                                                                                      
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #11 0x7f3e9590389f in sd_event_loop ../src/libsystemd/sd-event/sd-event.c:3319                                                                                                                                     
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #12 0x56292204f978 in run ../src/network/networkd.c:114
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #13 0x56292204fb8f in main ../src/network/networkd.c:121
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #14 0x7f3e93fbbce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #15 0x56292204dc6d in _start (/build/build/systemd-networkd+0x2ccc6d)
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]: 0x612000000a77 is located 0 bytes to the right of 311-byte region [0x612000000940,0x612000000a77)                                                                                                                      
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]: allocated by thread T0 here:
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #0 0x7f3e965215a1 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:95                                                                                                             
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #1 0x5629221f7c77 in client_receive_message_raw ../src/libsystemd-network/sd-dhcp-client.c:1850                                                                                                                    
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #2 0x7f3e958fbe62 in source_dispatch ../src/libsystemd/sd-event/sd-event.c:2827                                                                                                                                    
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #3 0x7f3e959025dd in sd_event_dispatch ../src/libsystemd/sd-event/sd-event.c:3240                                                                                                                                  
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #4 0x7f3e95903572 in sd_event_run ../src/libsystemd/sd-event/sd-event.c:3297                                                                                                                                       
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #5 0x7f3e9590389f in sd_event_loop ../src/libsystemd/sd-event/sd-event.c:3319                                                                                                                                      
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #6 0x56292204f978 in run ../src/network/networkd.c:114
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #7 0x56292204fb8f in main ../src/network/networkd.c:121
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]:     #8 0x7f3e93fbbce2 in __libc_start_main (/lib64/libc.so.6+0x23ce2)
Jun 28 06:40:01 arch.localdomain systemd-networkd[3942]: SUMMARY: AddressSanitizer: heap-buffer-overflow /build/gcc/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:326 in __interceptor_strndup                                                        


100 4232k  100 4232k    0     0   934k      0  0:00:04  0:00:04 --:--:--  934k
 ____________________________________________
/ Found  15 sanitizer errors ( 15 ASan,   0  \
| UBSan,   0 MSan). Looks like you need to   |
\ look at the log                            /
 --------------------------------------------
 \
  \
     __
    /  \
    |  |
    @  @
    |  |
    || |/
    || ||
    |\_/|
    \___/
```

As I'm pretty sure I didn't count for all patterns (and the UBSan pattern is, unfortunately, too general to my liking), I'd definitely welcome some feedback (@evverx).