### PR TITLE
agent/vagrant: extend timeout for other integration tests

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -89,7 +89,7 @@ TEST_LIST=(
 )
 
 for t in "${TEST_LIST[@]}"; do
-    exectask "${t##*/}" "timeout 30m ./$t"
+    exectask "${t##*/}" "timeout 45m ./$t"
 done
 
 # Summary

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -93,7 +93,7 @@ TEST_LIST=(
 )
 
 for t in "${TEST_LIST[@]}"; do
-    exectask "${t##*/}" "timeout 30m ./$t"
+    exectask "${t##*/}" "timeout 45m ./$t"
 done
 
 # Summary


### PR DESCRIPTION
This change is relevant mostly for the systemd-network testsuite, which
keeps growing and the original 30m timeout was simply not enough.

Fixes #140