### PR TITLE
Temporarily disable `detect_stack_use_after_return` check for gcc runs

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -14,8 +14,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
-  config.vm.box = "archlinux_systemd"
-  config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
+  config.vm.box = "generic/arch"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -68,6 +67,31 @@ Vagrant.configure("2") do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    set -e
+
+    whoami
+
+    # Initialize pacman's keyring
+    pacman-key --init
+    # Upgrade the system
+    pacman --noconfirm -Syu
+
+    # Install build dependencies
+    pacman --needed --noconfirm -S acl cryptsetup docbook-xsl gperf lz4 xz pam libelf intltool \
+        iptables kmod libcap libidn2 libgcrypt libmicrohttpd libxslt util-linux \
+        linux-api-headers python-lxml quota-tools shadow gnu-efi-libs git meson \
+        libseccomp pcre2 audit kexec-tools libxkbcommon bash-completion git ninja \
+        gcc m4 pkgconf ethtool
+    # Install test dependencies
+    # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
+    #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
+    pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
+        dnsmasq automake make dhclient rsync qemu socat wireguard-arch
+  SHELL
+
+  config.vm.provision :reload
+
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -e
 

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -14,8 +14,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
-  config.vm.box = "archlinux_systemd"
-  config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
+  config.vm.box = "generic/arch"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -67,7 +66,31 @@ Vagrant.configure("2") do |config|
 
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    set -e
+
+    whoami
+
+    # Initialize pacman's keyring
+    pacman-key --init
+    # Upgrade the system
+    pacman --noconfirm -Syu
+
+    # Install build dependencies
+    pacman --needed --noconfirm -S acl cryptsetup docbook-xsl gperf lz4 xz pam libelf intltool \
+        iptables kmod libcap libidn2 libgcrypt libmicrohttpd libxslt util-linux \
+        linux-api-headers python-lxml quota-tools shadow gnu-efi-libs git meson \
+        libseccomp pcre2 audit kexec-tools libxkbcommon bash-completion git ninja \
+        gcc m4 pkgconf ethtool
+    # Install test dependencies
+    # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
+    #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
+    pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
+        dnsmasq automake make dhclient rsync qemu socat wireguard-arch
+  SHELL
+
+  config.vm.provision :reload
+
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -e
 

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -27,5 +27,7 @@ if ! vagrant plugin list | grep vagrant-libvirt; then
     vagrant plugin install vagrant-libvirt
 fi
 
+vagrant plugin install vagrant-reload
+
 vagrant --version
 vagrant plugin list

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -18,6 +18,14 @@ pushd /build || (echo >&2 "Can't pushd to /build"; exit 1)
 export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
 export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
 
+# Temporary workaround for gcc 9.1.x
+# See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91101
+if ldd build/systemd | grep -q libasan.so; then
+    # Disable detect_stack_use_after_return check, which causes a huge performance
+    # regression in gcc 9.1.x
+    export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=0:check_initialization_order=1:strict_init_order=1
+fi
+
 _clang_asan_rt_name="$(ldd build/systemd | awk '/libclang_rt.asan/ {print $1; exit}')"
 
 if [[ -n "$_clang_asan_rt_name" ]]; then


### PR DESCRIPTION
Let's temporarily disable `disable detect_stack_use_after_return` check for gcc runs until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91101 is resolved.

See #137 