### PR TITLE
tree-wide: use -O1 -fno-omit-frame-pointer when compiling systemd

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -90,7 +90,7 @@ systemctl disable firewalld
 (
     # Make sure we copy over the meson logs even if the compilation fails
     trap "[[ -d $PWD/build/meson-logs ]] && cp -r $PWD/build/meson-logs '$LOGDIR'" EXIT
-    meson build -Dc_args='-g -O0 -ftrapv' \
+    meson build -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
                 --werror \
                 -Dslow-tests=true \
                 -Dtests=unsafe \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -91,7 +91,7 @@ Vagrant.configure("2") do |config|
     # Build phase
     meson build \
           --werror \
-          -Dc_args='-g -O0 -ftrapv' \
+          -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
           -Dslow-tests=true \
           -Dtests=unsafe \
           -Dinstall-tests=true \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -99,7 +99,7 @@ Vagrant.configure("2") do |config|
 
     meson build \
           --werror \
-          -Dc_args='-g -O0 -ftrapv' \
+          -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
           -Dtests=unsafe \
           -Dinstall-tests=true \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -93,7 +93,7 @@ Vagrant.configure("2") do |config|
     # Sanitizer (UBSan)
     meson build \
           --werror \
-          -Dc_args='-g -O0 -ftrapv' \
+          -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
           -Dtests=unsafe \
           -Dinstall-tests=true \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \


### PR DESCRIPTION
After @jakubjelinek's hint (thanks a lot for it) in https://github.com/systemd/systemd/issues/12997 I went through the sanitizer documentations again and learned something I managed to miss multiple times in the past. Originally, I put `-O0` everywhere as I thought other optimization levels would interfere with the sanitizers, causing potential false positives, break stack unwinding, etc. To my surprise, all sanitizer documentations recommend using at least `-O1` but with `-fno-omit-frame-pointer` to keep the stack unwinding untouched.

That being the case, let's use `-O1` for (almost) all systemd builds, which will have some performance impact during compilation, but this should be evened up (most likely several times) with a better runtime of the tests.

I noticed that `-Og` is basically `-O1` with some other debugging-interfering options turned off, but as I have no experience with it in combination with sanitizers, I decided to stick with `-O1` from the documentation.

@evverx any thoughts?