### PR TITLE
Performance improvements

### DIFF
--- a/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
+++ b/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
@@ -24,5 +24,5 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --no-index --vagrant arch-sanitizers-gcc $ARGS
+#./agent-control.py --no-index --vagrant arch-sanitizers-gcc $ARGS
 ./agent-control.py --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
+++ b/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+function at_exit() {
+    # Correctly collect artifacts from all sanitizer jobs and generate a nice
+    # directory structure
+    mkdir _artifacts_all
+    mv artifacts_* _artifacts_all
+    mv _artifacts_all artifacts_all
+
+    utils/generate-index.sh artifacts_all index.html
+}
+
+trap at_exit EXIT
+
+export PATH="/home/systemd/bin:$PATH"
+ARGS=
+
+if [ "$ghprbPullId" ]; then
+    ARGS="$ARGS --pr $ghprbPullId "
+fi
+
+git clone https://github.com/systemd/systemd-centos-ci
+cd systemd-centos-ci
+
+./agent-control.py --no-index --vagrant arch-sanitizers-gcc $ARGS
+./agent-control.py --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/jenkins/runners/systemd-pr-build-vagrant.sh
+++ b/jenkins/runners/systemd-pr-build-vagrant.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Add a local ~/bin dir to path for custom binaries (currently used only
+# for the tree binary for generating the artifact landing page)
+export PATH="/home/systemd/bin:$PATH"
+ARGS=
+
+if [ "$ghprbPullId" ]; then
+        ARGS="$ARGS --pr $ghprbPullId "
+fi
+
+git clone https://github.com/systemd/systemd-centos-ci
+cd systemd-centos-ci
+
+./agent-control.py --vagrant arch $ARGS

--- a/jenkins/runners/systemd-pr-build-vagrant.sh
+++ b/jenkins/runners/systemd-pr-build-vagrant.sh
@@ -5,8 +5,22 @@
 export PATH="/home/systemd/bin:$PATH"
 ARGS=
 
+set -e
+set -o pipefail
+
 if [ "$ghprbPullId" ]; then
-        ARGS="$ARGS --pr $ghprbPullId "
+    ARGS="$ARGS --pr $ghprbPullId "
+
+    # We're not testing the master branch, so let's see if the PR scope
+    # is something we should indeed test
+    git clone https://github.com/systemd/systemd systemd-tmp && cd systemd-tmp
+    git fetch -fu origin "refs/pull/$ghprbPullId/head:pr"
+    git checkout pr
+    SCOPE_RX='(^(catalog|factory|hwdb|meson.*|network|[^\.].*\.d$|rules|src|test|units))'
+    if ! git diff $(git merge-base master pr) --name-only | grep -E "$SCOPE_RX" ; then
+        echo "Changes in this PR don't seem relevant, skipping..."
+        exit 0
+    fi
 fi
 
 git clone https://github.com/systemd/systemd-centos-ci

--- a/jenkins/runners/systemd-pr-build.sh
+++ b/jenkins/runners/systemd-pr-build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Add a local ~/bin dir to path for custom binaries (currently used only
+# for the tree binary for generating the artifact landing page)
+export PATH="/home/systemd/bin:$PATH"
+ARGS=
+
+if [ "$ghprbPullId" ]; then
+        ARGS="$ARGS --pr $ghprbPullId "
+fi
+
+git clone https://github.com/systemd/systemd-centos-ci
+cd systemd-centos-ci
+
+./agent-control.py $ARGS

--- a/jenkins/runners/systemd-pr-build.sh
+++ b/jenkins/runners/systemd-pr-build.sh
@@ -5,8 +5,24 @@
 export PATH="/home/systemd/bin:$PATH"
 ARGS=
 
+set -e
+set -o pipefail
+
 if [ "$ghprbPullId" ]; then
-        ARGS="$ARGS --pr $ghprbPullId "
+    ARGS="$ARGS --pr $ghprbPullId "
+
+    # We're not testing the master branch, so let's see if the PR scope
+    # is something we should indeed test
+    git clone https://github.com/systemd/systemd systemd-tmp && cd systemd-tmp
+    git fetch -fu origin "refs/pull/$ghprbPullId/head:pr"
+    git checkout pr
+    # Let's make the regex here less strict, so we can, for example, test man page
+    # generation and other low-impact changes
+    SCOPE_RX='(^(catalog|factory|hwdb|man|meson.*|network|[^\.].*\.d$|rules|src|test|tools|units))'
+    if ! git diff $(git merge-base master pr) --name-only | grep -E "$SCOPE_RX" ; then
+        echo "Changes in this PR don't seem relevant, skipping..."
+        exit 0
+    fi
 fi
 
 git clone https://github.com/systemd/systemd-centos-ci


### PR DESCRIPTION
@evverx 

Following the proposal in https://github.com/systemd/systemd/pull/13087, I've put together a few changes which should help with the CentOS CI overload issue.

Changes:
1)  I moved the inline build scripts from Jenkins into this repo, which should improve transparency
2) The gcc part of the `systemd-pr-build-vagrant-sanitizers` job should be now disabled in favor of the clang one, to (hopefully temporarily) free up some resources
3) I proposed a *PR filter* to filter out some out-of-scope PRs from being tested

The PR filter limits the scope of changes to these folders/files:
```
$ SCOPE_RX='(^(catalog|factory|hwdb|meson.*|network|[^\.].*\.d$|rules|src|test|units))'
$ ls -a | grep -E "$SCOPE_RX"
catalog
factory
hwdb
meson.build
meson_options.txt
modprobe.d
network
rules
src
sysctl.d
sysusers.d
test
tmpfiles.d
units

```

However, to test the man-page generation, I relaxed the regex in the CentOS 7 job (`systemd-pr-build`) so we have it tested at least somewhere. If I managed to omit something from the regex, let me know.

Hopefully, this and the changes from #144 will make the CI a bit faster. (Right now the load statistics graph looks like something made by Bob Ross:
![image](https://user-images.githubusercontent.com/679338/61363365-2ddb3180-a884-11e9-9170-d078ad8b6f66.png)
)
