### PR TITLE
vagrant: do a sanity boot check before reboot

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -100,6 +100,20 @@ Vagrant.configure("2") do |config|
           -Dhtml=true
     ninja -C build
     ninja -C build install
+
+    # Make sure the revision we just compiled is actually bootable
+    (
+      # Enable as much debug logging as we can to make debugging easier
+      # (especially for boot issues)
+      export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console"
+      # Bump the QEMU timeout, since we're running without KVM
+      export QEMU_TIMEOUT=1200
+      # Skip the nspawn version of the test
+      export TEST_NO_NSPAWN=1
+
+      make -C test/TEST-01-BASIC clean setup run clean-again
+    ) 2>&1 | tee vagrant-arch-sanity-boot-check.log
+
     popd
   SHELL
 end


### PR DESCRIPTION
In some cases the just compiled revision may end up being unbootable,
and since we don't have access to the serial console of the VM, it's
more or less undebuggable. Let's do a simple sanity check before the
reboot itself (as we already do in the CentOS 7 job) to make
the debugging easier.

Fixes #149 