### PR TITLE
/dev/random shenanigans

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -68,6 +68,8 @@ Vagrant.configure("2") do |config|
     # This file needs to be collected later by vagrant-ci-wrapper.sh
     libvirt.qemuargs :value => "file:/tmp/vagrant-arch-serial-console.log"
 
+    # Pass through /dev/random from the host to the VM
+    libvirt.random :model => 'random'
   end
 
   # View the documentation for the provider you are using for more

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -60,6 +60,9 @@ Vagrant.configure("2") do |config|
     if ENV["VAGRANT_DISK_BUS"] then
       libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
     end
+
+    # Pass through /dev/random from the host to the VM
+    libvirt.random :model => 'random'
   end
 
   # View the documentation for the provider you are using for more

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -60,6 +60,9 @@ Vagrant.configure("2") do |config|
     if ENV["VAGRANT_DISK_BUS"] then
       libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
     end
+
+    # Pass through /dev/random from the host to the VM
+    libvirt.random :model => 'random'
   end
 
   # View the documentation for the provider you are using for more

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -32,6 +32,9 @@ Vagrant.configure("2") do |config|
     if ENV["VAGRANT_DISK_BUS"] then
       libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
     end
+
+    # Pass through /dev/random from the host to the VM
+    libvirt.random :model => 'random'
   end
 
   # View the documentation for the provider you are using for more


### PR DESCRIPTION
Let's pass through host's `/dev/random` using virtio-rng to satisfy entropy-intensive tasks, like the new random seed stuff.