### PR TITLE
vagrant: try to get a journal dump when ssh unexpectedly dies 

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -124,12 +124,6 @@ Vagrant.configure("2") do |config|
       make -C test/TEST-01-BASIC clean setup run clean-again
     ) 2>&1 | tee vagrant-arch-sanity-boot-check.log
 
-    # Disable 'quiet' mode on the kernel command line and forward everything
-    # to ttyS0 instead of just tty0, so we can collect it using QEMU's
-    # -serial file:xxx feature
-    sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/ { s/quiet//; s/"$/ console=ttyS0"/ }' /etc/default/grub
-    grub-mkconfig -o /boot/grub/grub.cfg
-
     popd
   SHELL
 end

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -61,6 +61,13 @@ Vagrant.configure("2") do |config|
       libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
     end
 
+    # Collect output from a serial console into a file to make debugging easier
+    # The -nographic option allows us to collect BIOS messages as well
+    libvirt.qemuargs :value => "-nographic"
+    libvirt.qemuargs :value => "-serial"
+    # This file needs to be collected later by vagrant-ci-wrapper.sh
+    libvirt.qemuargs :value => "file:/tmp/vagrant-arch-sanitizers-serial-console.log"
+
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
   end

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -61,6 +61,13 @@ Vagrant.configure("2") do |config|
       libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
     end
 
+    # Collect output from a serial console into a file to make debugging easier
+    # The -nographic option allows us to collect BIOS messages as well
+    libvirt.qemuargs :value => "-nographic"
+    libvirt.qemuargs :value => "-serial"
+    # This file needs to be collected later by vagrant-ci-wrapper.sh
+    libvirt.qemuargs :value => "file:/tmp/vagrant-arch-sanitizers-serial-console.log"
+
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
   end

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -63,5 +63,11 @@ Vagrant.configure("2") do |config|
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
         dnsmasq automake make dhclient rsync qemu socat wireguard-arch
+
+    # Disable 'quiet' mode on the kernel command line and forward everything
+    # to ttyS0 instead of just tty0, so we can collect it using QEMU's
+    # -serial file:xxx feature
+    sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/ { s/quiet//; s/"$/ console=ttyS0"/ }' /etc/default/grub
+    grub-mkconfig -o /boot/grub/grub.cfg
   SHELL
 end


### PR DESCRIPTION
In rare cases the `vagrant ssh` command dies unexpectedly (so far only
during the systemd-networkd testsuite) with EC 255. Let's add some
'hooks' to make this debuggable.

This, of course, works only if the sudden connection loss was just
intermittent. If the network gets completely broken, this won't work as
well.