### PR TITLE
Collect potential coredumps after running the testsuite 

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -42,7 +42,7 @@ sed -i 's/skip_if_unavailable=True/skip_if_unavailable=False/' "$COPR_REPO_PATH"
 if ! rpm --import https://copr-be.cloud.fedoraproject.org/results/mrc0mmand/systemd-centos-ci/pubkey.gpg; then
     rpm --import http://artifacts.ci.centos.org/systemd/mrc0mmand-systemd-centos-ci/pubkey.gpg
 fi
-yum -q -y install epel-release yum-utils
+yum -q -y install epel-release yum-utils gdb
 yum-config-manager -q --enable epel
 yum -q -y update
 

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -94,6 +94,7 @@ exectask_p_finish
 for t in test/TEST-??-*; do
     journal_path="/var/tmp/systemd-test-${t##*/}/journal"
     if [[ -d "$journal_path" ]]; then
+        # Attempt to collect coredumps from test-specific journals as well
         exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$journal_path'"
         rsync -aq "$journal_path" "$LOGDIR/${t##*/}"
     fi

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -92,8 +92,10 @@ exectask_p_finish
 
 # Save journals created by integration tests
 for t in test/TEST-??-*; do
-    if [[ -d /var/tmp/systemd-test-${t##*/}/journal ]]; then
-        rsync -aq "/var/tmp/systemd-test-${t##*/}/journal" "$LOGDIR/${t##*/}"
+    journal_path="/var/tmp/systemd-test-${t##*/}/journal"
+    if [[ -d "$journal_path" ]]; then
+        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$journal_path'"
+        rsync -aq "$journal_path" "$LOGDIR/${t##*/}"
     fi
 done
 

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 . "$(dirname "$0")/../common/task-control.sh" "testsuite-logs-upstream" || exit 1
+. "$(dirname "$0")/../common/utils.sh" || exit 1
 
 # EXIT signal handler
 function at_exit {
@@ -13,6 +14,12 @@ trap at_exit EXIT
 ### SETUP PHASE ###
 # Exit on error in the setup phase
 set -e -u
+
+# Enable systemd-coredump
+if ! coredumpctl_init; then
+    echo >&2 "Failed to configure systemd-coredump/coredumpctl"
+    exit 1
+fi
 
 if [[ ! -f /usr/bin/ninja ]]; then
     ln -s /usr/bin/ninja-build /usr/bin/ninja
@@ -99,6 +106,9 @@ TEST_LIST=(
 for t in "${TEST_LIST[@]}"; do
     exectask "${t##*/}" "timeout 45m ./$t"
 done
+
+# Collect coredumps using the coredumpctl utility, if any
+exectask "coredumpctl_collect" "coredumpctl_collect"
 
 # Summary
 echo

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -84,7 +84,7 @@ for t in test/TEST-??-*; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask_p "${t##*/}" "make -C $t clean setup run clean-again"
+    exectask_p "${t##*/}" "make -C $t clean setup run"
 done
 
 # Wait for remaining running tasks

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/bash
 # This file contains useful functions shared among scripts from this repository
 
+__COREDUMPCTL_TS=""
+
 # Checkout to the requsted branch:
 #   1) if pr:XXX where XXX is a pull request ID is passed to the script,
 #      the corresponding branch for this PR is be checked out
@@ -102,4 +104,73 @@ check_for_sanitizer_errors() {
         }
     }
     '
+}
+
+# Enable coredump collection using systemd-coredump
+#
+# Basically just enable systemd-coredump.socket and check if coredumpctl doesn't
+# crash on when invoked
+coredumpctl_init() {
+    local EC
+
+    if ! systemctl start systemd-coredump.socket; then
+        echo >&2 "[$FUNCNAME] Failed to start systemd-coredump.socket"
+        return 1
+    fi
+    # Let's make sure coredumpctl doesn't crash on invocation
+    # Note: coredumpctl returns 1 when no coredumps are found, so accept this EC
+    # as a success as well
+    coredumpctl > /dev/null
+    EC=$?
+
+    if ! [[ $EC -eq 0 || $EC -eq 1 ]]; then
+        echo >&2 "[$FUNCNAME] coredumpctl is not in operative state"
+        return 1
+    fi
+}
+
+# Set the timestamp for future coredump collection using coredumpctl_collect()
+# Arguments:
+#   $1 - timestamp to set. If empty, the current date & time is used instead
+coredumpctl_set_ts() {
+    __COREDUMPCTL_TS="${1:-$(date +"%Y-%m-%d %H:%M:%S")}"
+}
+
+# Attempt to dump info about relevant coredumps using the coredumpctl utility.
+#
+# To limit the collection scope (e.g. only consider coredumps since a certain
+# date), use the coredumpctl_set_ts() function
+coredumpctl_collect() {
+    local ARGS=(--no-legend --no-pager)
+    local TEMPFILE="$(mktemp)"
+
+    # Register a cleanup handler
+    trap "rm -f '$TEMPFILE'" EXIT
+
+    echo "[$FUNCNAME] Attempting to collect info about possible coredumps"
+
+    # If coredumpctl_set_ts() was called beforehand, use the saved timestamp
+    if [[ -n "$__COREDUMPCTL_TS" ]]; then
+        ARGS+=(--since "$__COREDUMPCTL_TS")
+    fi
+
+    # Collect executable paths of all coredumps and filter out the expected ones
+    # FILTER_RX:
+    #   test-execute - certain subtests die with SIGSEGV intentionally
+    FILTER_RX="/test-execute$"
+    if ! coredumpctl "${ARGS[@]}" -F COREDUMP_EXE | grep -Ev "$FILTER_RX" > "$TEMPFILE"; then
+        echo "[$FUNCNAME] No relevant coredumps found"
+        return 0
+    fi
+
+    # For each unique executable path call 'coredumpctl info' to get the stack
+    # trace and other useful info
+    while read -r path; do
+        coredumpctl "${ARGS[@]}" info "$path"
+        # Attempt to get a full stack trace for the first occurrence of the
+        # given executable path
+        echo -e "bt full\nquit" | coredumpctl "${ARGS[@]}" debug "$path"
+    done <<< "$(sort -u $TEMPFILE)"
+
+    return 1
 }

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -109,7 +109,10 @@ check_for_sanitizer_errors() {
 # Enable coredump collection using systemd-coredump
 #
 # Basically just enable systemd-coredump.socket and check if coredumpctl doesn't
-# crash on when invoked
+# crash when invoked
+#
+# Returns:
+#   0 when both systemd-coredump & coredumpctl work as expected, 1 otherwise
 coredumpctl_init() {
     local EC
 
@@ -117,6 +120,7 @@ coredumpctl_init() {
         echo >&2 "[$FUNCNAME] Failed to start systemd-coredump.socket"
         return 1
     fi
+
     # Let's make sure coredumpctl doesn't crash on invocation
     # Note: coredumpctl returns 1 when no coredumps are found, so accept this EC
     # as a success as well
@@ -130,6 +134,7 @@ coredumpctl_init() {
 }
 
 # Set the timestamp for future coredump collection using coredumpctl_collect()
+#
 # Arguments:
 #
 #   $1: timestamp to set. If empty, the current date & time is used instead
@@ -139,11 +144,14 @@ coredumpctl_set_ts() {
 
 # Attempt to dump info about relevant coredumps using the coredumpctl utility.
 #
-# To limit the collection scope (e.g. only consider coredumps since a certain
+# To limit the collection scope (e.g. consider coredumps only since a certain
 # date), use the coredumpctl_set_ts() function
 #
 # Arguments:
 #   $1: (optional) path to a directory with journal files
+#
+# Returns:
+#   0 when no coredumps were found, 1 otherwise
 coredumpctl_collect() {
     local ARGS=(--no-legend --no-pager)
     local JOURNALDIR="${1:-}"

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -188,11 +188,14 @@ coredumpctl_collect() {
     # For each unique executable path call 'coredumpctl info' to get the stack
     # trace and other useful info
     while read -r path; do
+        echo "[$FUNCNAME] Gathering coredumps for '$path'"
         coredumpctl "${ARGS[@]}" info "$path"
         # Attempt to get a full stack trace for the first occurrence of the
         # given executable path
         if gdb -v > /dev/null; then
+            echo -e "\n[$FUNCNAME] Trying to run gdb with 'bt full' for '$path'"
             echo -e "bt full\nquit" | coredumpctl "${ARGS[@]}" debug "$path"
+            echo -e "\n"
         fi
     done <<< "$(sort -u $TEMPFILE)"
 

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -183,7 +183,9 @@ coredumpctl_collect() {
         coredumpctl "${ARGS[@]}" info "$path"
         # Attempt to get a full stack trace for the first occurrence of the
         # given executable path
-        echo -e "bt full\nquit" | coredumpctl "${ARGS[@]}" debug "$path"
+        if gdb -v > /dev/null; then
+            echo -e "bt full\nquit" | coredumpctl "${ARGS[@]}" debug "$path"
+        fi
     done <<< "$(sort -u $TEMPFILE)"
 
     return 1

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S net-tools strace openbsd-netcat busybox e2fsprogs quota-tools \
-        dnsmasq automake make dhclient rsync qemu socat wireguard-arch
+        dnsmasq automake make dhclient rsync qemu socat wireguard-arch gdb
 
     # Disable 'quiet' mode on the kernel command line and forward everything
     # to ttyS0 instead of just tty0, so we can collect it using QEMU's

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -54,7 +54,7 @@ for t in test/TEST-??-*; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask_p "${t##*/}" "make -C $t clean setup run"
+    exectask_p "${t##*/}" "make -C $t clean setup run && touch $TESTDIR/pass"
 done
 
 # Wait for remaining running tasks
@@ -84,18 +84,22 @@ for t in "${SERIALIZED_TASKS[@]}"; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask "${t##*/}" "make -C $t clean setup run"
+    exectask "${t##*/}" "make -C $t clean setup run && touch $TESTDIR/pass"
 done
 
 # Save journals created by integration tests
 for t in test/TEST-??-*; do
-    journal_path="/var/tmp/systemd-test-${t##*/}/journal"
-    if [[ -d "$journal_path" ]]; then
+    testdir="/var/tmp/systemd-test-${t##*/}"
+    if [[ -d "$testdir/journal" ]]; then
         # Attempt to collect coredumps from test-specific journals as well
-        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$journal_path'"
-        rsync -aq "$journal_path" "$LOGDIR/${t##*/}"
+        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/journal'"
+        # Keep the journal files only if the associated test case failed
+        if [[ ! -f "$testdir/pass" ]]; then
+            rsync -aq "$testdir/journal" "$LOGDIR/${t##*/}"
+        fi
     fi
 done
+
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -54,7 +54,7 @@ for t in test/TEST-??-*; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask_p "${t##*/}" "make -C $t clean setup run clean-again"
+    exectask_p "${t##*/}" "make -C $t clean setup run"
 done
 
 # Wait for remaining running tasks
@@ -84,7 +84,7 @@ for t in "${SERIALIZED_TASKS[@]}"; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask "${t##*/}" "make -C $t clean setup run clean-again"
+    exectask "${t##*/}" "make -C $t clean setup run"
 done
 
 # Save journals created by integration tests

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -91,6 +91,7 @@ done
 for t in test/TEST-??-*; do
     journal_path="/var/tmp/systemd-test-${t##*/}/journal"
     if [[ -d "$journal_path" ]]; then
+        # Attempt to collect coredumps from test-specific journals as well
         exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$journal_path'"
         rsync -aq "$journal_path" "$LOGDIR/${t##*/}"
     fi

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -89,11 +89,12 @@ done
 
 # Save journals created by integration tests
 for t in test/TEST-??-*; do
-    if [[ -d /var/tmp/systemd-test-${t##*/}/journal ]]; then
-        rsync -aq "/var/tmp/systemd-test-${t##*/}/journal" "$LOGDIR/${t##*/}"
+    journal_path="/var/tmp/systemd-test-${t##*/}/journal"
+    if [[ -d "$journal_path" ]]; then
+        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$journal_path'"
+        rsync -aq "$journal_path" "$LOGDIR/${t##*/}"
     fi
 done
-
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"


### PR DESCRIPTION
Fixes #160 

---

~~So far this shows only stack traces from all coredumps. Calling `bt full` on every coredump would be definitely handy, but right now this would be somewhat cumbersome, as `coredumpctl` doesn't allow overriding/editing the `$SYSTEMD_DEBUGGER` command line, and `.gdbinit` runs before the gdb is properly initialized with passed arguments (executable & coredump).~~