### PR TITLE
vagrant: enable nested KVM

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -70,6 +70,10 @@ Vagrant.configure("2") do |config|
 
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
+
+    # Enable nested KVM
+    libvirt.nested = true
+    libvirt.cpu_mode = "host-model"
   end
 
   # View the documentation for the provider you are using for more
@@ -116,10 +120,11 @@ Vagrant.configure("2") do |config|
       # Enable as much debug logging as we can to make debugging easier
       # (especially for boot issues)
       export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console"
-      # Bump the QEMU timeout, since we're running without KVM
-      export QEMU_TIMEOUT=1200
+      export QEMU_TIMEOUT=600
       # Skip the nspawn version of the test
       export TEST_NO_NSPAWN=1
+      # Enforce nested KVM
+      export TEST_NESTED_KVM=1
 
       make -C test/TEST-01-BASIC clean setup run clean-again
     ) 2>&1 | tee vagrant-arch-sanity-boot-check.log

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -70,6 +70,10 @@ Vagrant.configure("2") do |config|
 
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
+
+    # Enable nested KVM
+    libvirt.nested = true
+    libvirt.cpu_mode = "host-model"
   end
 
   # View the documentation for the provider you are using for more

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -70,6 +70,10 @@ Vagrant.configure("2") do |config|
 
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
+
+    # Enable nested KVM
+    libvirt.nested = true
+    libvirt.cpu_mode = "host-model"
   end
 
   # View the documentation for the provider you are using for more

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -6,8 +6,32 @@
 
 VAGRANT_PKG_URL="https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.4_x86_64.rpm"
 
-set -e -u
 set -o pipefail
+set -e -u
+
+# Set up nested KVM
+# Let's make all errors "soft", at least for now, as we're still perfectly
+# fine with running tests without nested KVM
+if KVM_MODULE_NAME="$(lsmod | grep -m1 -Eo '(kvm_intel|kvm_amd)')"; then
+    echo "[vagrant-setup] Detected KVM module: $KVM_MODULE_NAME"
+    # Attempt to reload the detected KVM module with nested=1 parameter
+    if modprobe -v -r $KVM_MODULE_NAME && modprobe -v $KVM_MODULE_NAME nested=1; then
+        # The reload was successful, check if the module's 'nested' parameter
+        # confirms that nested KVM is indeed enabled
+        KVM_MODULE_NESTED="$(< /sys/module/$KVM_MODULE_NAME/parameters/nested)" || :
+        echo "[vagrant-setup] /sys/module/$KVM_MODULE_NAME/parameters/nested: $KVM_MODULE_NESTED"
+
+        if [[ "$KVM_MODULE_NESTED" =~ (1|Y) ]]; then
+            echo "[vagrant-setup] Nested KVM is enabled"
+        else
+            echo "[vagrant-setup] Failed to enable nested KVM"
+        fi
+    else
+        echo "[vagrant-setup] Failed to reload module '$KVM_MODULE_SETUP'"
+    fi
+else
+    echo "[vagrant-setup] No KVM module found, can't setup nested KVM"
+fi
 
 if ! vagrant version 2>/dev/null; then
     # Install Vagrant

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -35,7 +35,6 @@ exectask "ninja-test_sanitizers" "meson test -C build --print-errorlogs --timeou
 
 ## Run TEST-01-BASIC under test sanitizers
 # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
-# As we're not using KVM, bump the QEMU timeout quite a bit
 export QEMU_TIMEOUT=600
 export NSPAWN_TIMEOUT=600
 # Set QEMU_SMP to speed things up
@@ -43,6 +42,8 @@ export QEMU_SMP=$(nproc)
 # Arch Linux requires booting with initrd, as all commonly used filesystems
 # are compiled in as modules
 export SKIP_INITRD=no
+# Enforce nested KVM
+export TEST_NESTED_KVM=yes
 
 # Enable systemd-coredump
 if ! coredumpctl_init; then

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -40,14 +40,15 @@ for t in test/TEST-??-*; do
 
     ## Configure test environment
     # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
-    # As we're not using KVM, bump the QEMU timeout quite a bit
-    export QEMU_TIMEOUT=2000
+    export QEMU_TIMEOUT=900
     export NSPAWN_TIMEOUT=900
     # Set the test dir to something predictable so we can refer to it later
     export TESTDIR="/var/tmp/systemd-test-${t##*/}"
     # Set QEMU_SMP appropriately (regarding the parallelism)
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
+    # Enforce nested KVM
+    export TEST_NESTED_KVM=1
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
@@ -70,14 +71,15 @@ SERIALIZED_TASKS=(
 for t in "${SERIALIZED_TASKS[@]}"; do
     ## Configure test environment
     # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
-    # As we're not using KVM, bump the QEMU timeout quite a bit
-    export QEMU_TIMEOUT=2000
+    export QEMU_TIMEOUT=600
     export NSPAWN_TIMEOUT=600
     # Set the test dir to something predictable so we can refer to it later
     export TESTDIR="/var/tmp/systemd-test-${t##*/}"
     # Set QEMU_SMP appropriately (regarding the parallelism)
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
+    # Enforce nested KVM
+    export TEST_NESTED_KVM=1
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 


### PR DESCRIPTION
As nested KVM got much more stable in recent years, let's give it a try
and attempt to use it by default to speed up tests under Vagrant.

The nested KVM setup requires two steps:
1) Enable nested KVM on the host system (modprobe kvm_* nested=1)
2) Tell the vagrant-libvirt plugin to use it (domain.nested = true)
