### PR TITLE
agent: pin meson to v0.51.2

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -47,7 +47,7 @@ yum-config-manager -q --enable epel
 yum -q -y update
 yum -q -y install systemd-ci-environment libidn2-devel python-lxml python36 ninja-build libasan net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm
 python3.6 -m ensurepip
-python3.6 -m pip install meson
+python3.6 -m pip install meson==0.51.2
 
 # python36 package doesn't create the python3 symlink
 rm -f /usr/bin/python3

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -47,7 +47,7 @@ yum-config-manager -q --enable epel
 yum -q -y update
 yum -q -y install systemd-ci-environment python-lxml python36 ninja-build libasan net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm
 python3.6 -m ensurepip
-python3.6 -m pip install meson
+python3.6 -m pip install meson==0.51.2
 
 # python36 package doesn't create the python3 symlink
 rm -f /usr/bin/python3


### PR DESCRIPTION
The latest meson version (0.52.0) introduced an issue, where the
configure/setup phase ends up in an endless loop. Until it's resolved,
let's pin meson to its last working version.

See: systemd/systemd#13742