### PR TITLE
agent: install libbpf-devel on CentOS 7

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -45,7 +45,8 @@ fi
 yum -q -y install epel-release yum-utils gdb
 yum-config-manager -q --enable epel
 yum -q -y update
-yum -q -y install systemd-ci-environment python-lxml python36 ninja-build libasan net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm pcre2-devel
+yum -q -y install busybox dnsmasq e2fsprogs libasan libbpf-devel nc net-tools ninja-build \
+                  pcre2-devel python36 python-lxml qemu-kvm quota strace systemd-ci-environment
 python3.6 -m ensurepip
 python3.6 -m pip install meson==0.51.2
 


### PR DESCRIPTION
This uses the systemd-centos-ci COPR repo until the official libbpf
package is available in EPEL