### PR TITLE
vagrant: compile & install libbpf-next library

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -70,6 +70,15 @@ Vagrant.configure("2") do |config|
     python3 -m ensurepip
     python3 -m pip install meson==0.51.2
 
+    # Compile & install libbpf-next
+    pacman --needed --noconfirm -S elfutils libelf
+    git clone https://github.com/libbpf/libbpf libbpf
+    pushd libbpf/src
+    LD_FLAGS="-Wl,--no-as-needed" NO_PKG_CONFIG=1 make
+    make install
+    popd
+    rm -fr libbpf
+
     # Disable 'quiet' mode on the kernel command line and forward everything
     # to ttyS0 instead of just tty0, so we can collect it using QEMU's
     # -serial file:xxx feature


### PR DESCRIPTION
See: https://github.com/systemd/systemd/pull/13744

---

Theoretically, we could use the `bcc` AUR package, but as we'd have to compile it locally with all necessary dependencies, it's much easier and faster to just clone & compile libbpf-next directly. And as a benefit we'll always get the latest version!