### PR TITLE
Revert recent Vagrant workarounds

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -17,7 +17,6 @@ Vagrant.configure("2") do |config|
   # in the CentOS CI infrastructure due to unwritable keyring
   # config.vm.box = "archlinux/archlinux"
   config.vm.box = "generic/arch"
-  config.vm.box_version = "1.9.34"
   # Don't replace the original Vagrant's insecure key
   config.ssh.insert_key = false
 


### PR DESCRIPTION
Fixes #174. I'll leave the `dhcpcd` thing untouched, for now, as it make sense until we're able to change the lease time of the DHCP daemon in libvirt.