### PR TITLE
vagrant: beef up the dhcpcd 'workaround' a little

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -127,7 +127,7 @@ Vagrant.configure("2") do |config|
       export TEST_NESTED_KVM=1
 
       make -C test/TEST-01-BASIC clean setup run clean-again
-    ) 2>&1 | tee vagrant-arch-sanity-boot-check.log
+    ) 2>&1 | grep --line-buffered '^' | tee vagrant-arch-sanity-boot-check.log
 
     popd
   SHELL

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -82,7 +82,7 @@ systemctl reload dbus.service
 # As the DHCP lease time in libvirt is quite short, and it's not configurable,
 # yet, let's start a DHCP daemon _only_ for the "master" network device to
 # keep it up during the systemd-networkd testsuite
-dhcpcd -q eth0
+dhcpcd --reconfigure --persistent --waitip -q eth0
 
 exectask "systemd-networkd_sanitizers" \
             "test/test-network/systemd-networkd-tests.py --build-dir=$PWD/build --debug --asan-options=$ASAN_OPTIONS --ubsan-options=$UBSAN_OPTIONS" \

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -115,7 +115,7 @@ systemctl reload dbus.service
 # As the DHCP lease time in libvirt is quite short, and it's not configurable,
 # yet, let's start a DHCP daemon _only_ for the "master" network device to
 # keep it up during the systemd-networkd testsuite
-dhcpcd -q eth0
+dhcpcd --reconfigure --persistent --waitip -q eth0
 
 for t in "${TEST_LIST[@]}"; do
     exectask "${t##*/}" "timeout -k 60s 45m ./$t"


### PR DESCRIPTION
The current "version" of the workaround caused some race conditions, especially in sanitizer runs. Let's try to make it a little bit more robust.

Originally, I wanted to use a separate net device with a static IP address to fix the issue once for all. Unfortunately, due to constellation of events and implementation details along the vagrant-libvirt plugin & Arch images, this is simply not possible, at least for now (`config.vm.network` directives fail with the current Arch images and using a static IP for the management netdev is impossible with the current libvirt/dnsmasq implementation).