### PR TITLE
vagrant: debug & fix systemd-networkd testsuite

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -83,5 +83,16 @@ Vagrant.configure("2") do |config|
     # -serial file:xxx feature
     sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/ { s/quiet//; s/"$/ console=ttyS0"/ }' /etc/default/grub
     grub-mkconfig -o /boot/grub/grub.cfg
+
+    # Tell systemd-networkd to ignore eth0 netdev, so we can keep it up
+    # during the systemd-networkd testsuite
+    cat << EOF > /etc/systemd/network/eth0.network
+    [Match]
+    Name=eth0
+
+    [Link]
+    Unmanaged=yes
+EOF
+
   SHELL
 end

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -85,7 +85,7 @@ systemctl reload dbus.service
 dhcpcd --reconfigure --persistent --waitip -q eth0
 
 exectask "systemd-networkd_sanitizers" \
-            "test/test-network/systemd-networkd-tests.py --build-dir=$PWD/build --debug --asan-options=$ASAN_OPTIONS --ubsan-options=$UBSAN_OPTIONS"
+            "timeout -k 60s 45m test/test-network/systemd-networkd-tests.py --build-dir=$PWD/build --debug --asan-options=$ASAN_OPTIONS --ubsan-options=$UBSAN_OPTIONS"
 
 exectask "check-networkd-log-for-sanitizer-errors" "cat $LOGDIR/systemd-networkd_sanitizers*.log | check_for_sanitizer_errors"
 exectask "check-journal-for-sanitizer-errors" "journalctl -b | check_for_sanitizer_errors"

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -85,8 +85,7 @@ systemctl reload dbus.service
 dhcpcd --reconfigure --persistent --waitip -q eth0
 
 exectask "systemd-networkd_sanitizers" \
-            "test/test-network/systemd-networkd-tests.py --build-dir=$PWD/build --debug --asan-options=$ASAN_OPTIONS --ubsan-options=$UBSAN_OPTIONS" \
-            1 # Ignore this task's exit code
+            "test/test-network/systemd-networkd-tests.py --build-dir=$PWD/build --debug --asan-options=$ASAN_OPTIONS --ubsan-options=$UBSAN_OPTIONS"
 
 exectask "check-networkd-log-for-sanitizer-errors" "cat $LOGDIR/systemd-networkd_sanitizers*.log | check_for_sanitizer_errors"
 exectask "check-journal-for-sanitizer-errors" "journalctl -b | check_for_sanitizer_errors"


### PR DESCRIPTION
Since October 21st the whole systemd-networkd testsuite is failing under sanitizers due to `Permission denied` errors when trying to execute binaries from the build dir:

```
======================================================================
ERROR: test_glob (__main__.NetworkctlTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test-network/systemd-networkd-tests.py", line 461, in test_glob
    self.wait_online(['test1:degraded'])
  File "test/test-network/systemd-networkd-tests.py", line 364, in wait_online
    output = check_output(*networkctl_cmd, 'status', link.split(':')[0])
  File "test/test-network/systemd-networkd-tests.py", line 43, in check_output
    return subprocess.check_output(command, universal_newlines=True, **kwargs).rstrip()
  File "/usr/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.7/subprocess.py", line 472, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
PermissionError: [Errno 13] Permission denied: '/build/build/networkctl'
```

Let's find the culprit and fix it.