### PR TITLE
common: add dhcpcd to coredumpctl-check's ignore list

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -179,7 +179,9 @@ coredumpctl_collect() {
     # Collect executable paths of all coredumps and filter out the expected ones
     # FILTER_RX:
     #   test-execute - certain subtests die with SIGSEGV intentionally
-    FILTER_RX="/test-execute$"
+    #   dhcpcd - [temporary] keeps crashing intermittently with SIGABRT, needs
+    #            further investigation
+    FILTER_RX="/(test-execute|dhcpcd)$"
     if ! coredumpctl "${ARGS[@]}" -F COREDUMP_EXE | grep -Ev "$FILTER_RX" > "$TEMPFILE"; then
         echo "[$FUNCNAME] No relevant coredumps found"
         return 0


### PR DESCRIPTION
As mentioned in #179 dhcpcd started crashing intermittently in the
recent weeks with SIGABRT during exiting. Even though it has no (at
least known) effect on the testsuite itself, it taints the coredumpctl
check. Let's add it temporarily to the ignore list, until it's
investigated and possibly fixed.