### PR TITLE
tree-wide: replace certain CFLAGS with their native meson options

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -45,7 +45,7 @@ fi
 yum -q -y install epel-release yum-utils gdb
 yum-config-manager -q --enable epel
 yum -q -y update
-yum -q -y install busybox dnsmasq e2fsprogs libasan libbpf-devel nc net-tools ninja-build \
+yum -q -y install busybox dnsmasq e2fsprogs gcc-c++ libasan libbpf-devel nc net-tools ninja-build \
                   pcre2-devel python36 python-lxml qemu-kvm quota strace systemd-ci-environment
 python3.6 -m ensurepip
 python3.6 -m pip install meson==0.51.2

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -91,7 +91,9 @@ systemctl disable firewalld
 (
     # Make sure we copy over the meson logs even if the compilation fails
     trap "[[ -d $PWD/build/meson-logs ]] && cp -r $PWD/build/meson-logs '$LOGDIR'" EXIT
-    meson build -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
+    meson build -Dc_args='-fno-omit-frame-pointer -ftrapv' \
+                --buildtype=debug \
+                --optimization=1 \
                 --werror \
                 -Dslow-tests=true \
                 -Dtests=unsafe \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -105,7 +105,9 @@ Vagrant.configure("2") do |config|
     # Build phase
     meson build \
           --werror \
-          -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
+          -Dc_args='-fno-omit-frame-pointer -ftrapv' \
+          --buildtype=debug \
+          --optimization=1 \
           -Dslow-tests=true \
           -Dtests=unsafe \
           -Dinstall-tests=true \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -113,7 +113,9 @@ Vagrant.configure("2") do |config|
 
     meson build \
           --werror \
-          -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
+          -Dc_args='-fno-omit-frame-pointer -ftrapv' \
+          --buildtype=debug \
+          --optimization=1 \
           -Dtests=unsafe \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \
           -Dman=false \

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -107,7 +107,9 @@ Vagrant.configure("2") do |config|
     # Sanitizer (UBSan)
     meson build \
           --werror \
-          -Dc_args='-g -O1 -fno-omit-frame-pointer -ftrapv' \
+          -Dc_args='-fno-omit-frame-pointer -ftrapv' \
+          --buildtype=debug \
+          --optimization=1 \
           -Dtests=unsafe \
           -Ddbuspolicydir=/usr/share/dbus-1/system.d \
           -Dman=false \


### PR DESCRIPTION
```
CFLAGS=-O1 => --optimization=1
CFLAGS=-g  => --buildtype=debug
```
---

See: https://github.com/systemd/systemd/issues/13742#issuecomment-549059700