### PR TITLE
vagrant: make the ssh connection a little bit more reliable

### DIFF
--- a/vagrant/Vagrantfiles/Vagrantfile_arch
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch
@@ -76,6 +76,13 @@ Vagrant.configure("2") do |config|
     libvirt.cpu_mode = "host-model"
   end
 
+  config.ssh.extra_args = [
+    "-o", "ConnectionAttempts=60",
+    "-o", "ConnectTimeout=180",
+    "-o", "ServerAliveInterval=2",
+    "-o", "TCPKeepAlive=yes"
+  ]
+
   # View the documentation for the provider you are using for more
   # information on available options.
 

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-clang
@@ -76,6 +76,13 @@ Vagrant.configure("2") do |config|
     libvirt.cpu_mode = "host-model"
   end
 
+  config.ssh.extra_args = [
+    "-o", "ConnectionAttempts=60",
+    "-o", "ConnectTimeout=180",
+    "-o", "ServerAliveInterval=2",
+    "-o", "TCPKeepAlive=yes"
+  ]
+
   # View the documentation for the provider you are using for more
   # information on available options.
 

--- a/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
+++ b/vagrant/Vagrantfiles/Vagrantfile_arch-sanitizers-gcc
@@ -76,6 +76,13 @@ Vagrant.configure("2") do |config|
     libvirt.cpu_mode = "host-model"
   end
 
+  config.ssh.extra_args = [
+    "-o", "ConnectionAttempts=60",
+    "-o", "ConnectTimeout=180",
+    "-o", "ServerAliveInterval=2",
+    "-o", "TCPKeepAlive=yes"
+  ]
+
   # View the documentation for the provider you are using for more
   # information on available options.
 


### PR DESCRIPTION
The *default* settings weren't much reliable, especially during the systemd-networkd teststuite, which messes around with the routes. Hopefully, this will make them a little bit more reliable.