### PR TITLE
vagrant: use TCP instead of UDP for NFS

### DIFF
--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -57,12 +57,6 @@ if ! vagrant plugin list | grep vagrant-libvirt; then
     export GEM_PATH=$GEM_HOME:/opt/vagrant/embedded/gems
     export PATH=/opt/vagrant/embedded/bin:$PATH
     vagrant plugin install vagrant-libvirt
-
-    # Enable NFS over UDP, which Vagrant uses by default
-    # (this used to work on CentOS 7, as UDP was enabled by default for nfsd)
-    sed -i '/\[nfsd\]/a udp=y' /etc/nfs.conf
-    systemctl restart nfs-server.service
-    systemctl status nfs-server.service
 fi
 
 vagrant --version

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ENV["SYSTEMD_ROOT"], "/build"
+  config.vm.synced_folder ENV["SYSTEMD_ROOT"], "/build", type: "nfs", nfs_udp: false
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -81,8 +81,8 @@ Vagrant.configure("2") do |config|
   config.ssh.extra_args = [
     "-o", "ConnectionAttempts=60",
     "-o", "ConnectTimeout=180",
-    "-o", "ServerAliveInterval=2",
-    "-o", "TCPKeepAlive=yes"
+    "-o", "ServerAliveInterval=15",
+    "-o", "TCPKeepAlive=no"
   ]
 
   # Use an external bootstrap script if set


### PR DESCRIPTION
This should make the share more reliable and should also fix
compatibility issues with newer NFS versions (like v4) which don't
support UDP transport anymore.