### PR TITLE
jenkins: switch the RHEL 8 job back to CentOS 8

### DIFF
--- a/jenkins/runners/systemd-rhel8-pr-build.sh
+++ b/jenkins/runners/systemd-rhel8-pr-build.sh
@@ -28,4 +28,4 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --version 8-stream --rhel 8 $ARGS
+./agent-control.py --version 8 --rhel 8 $ARGS


### PR DESCRIPTION
CentOS 8-stream has empty source repositories, which breaks the CI
during the `dnf builddep` phase. Switch back to CentOS 8 for now, to
mitigate this.

See:
https://bugs.centos.org/view.php?id=16715
https://lists.centos.org/pipermail/ci-users/2019-November/000981.html