### PR TITLE
vagrant: disable test-journal-flush on nested KVM

### DIFF
--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -30,6 +30,10 @@ if [[ -n "$_clang_asan_rt_name" ]]; then
     ldconfig
 fi
 
+# Disable certain flaky tests
+# test-journal-flush: unstable on nested KVM
+echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
+
 # Run the internal unit tests (make check)
 exectask "ninja-test_sanitizers" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -21,6 +21,10 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
+# Disable certain flaky tests
+# test-journal-flush: unstable on nested KVM
+echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 


### PR DESCRIPTION
The test has been pretty unstable for a while, consequently since the
nested KVM was enabled. As the test still runs on the *bare* CentOS,
let's disable it in Vagrant jobs to make them more reliable.