### PR TITLE
agent: bump the upstream CentOS 7 job to CentOS 8

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -117,6 +117,15 @@ grubby --args="user_namespace.enable=1" --update-kernel="$(grubby --default-kern
 grep -r "user_namespace.enable=1" /boot/loader/entries/
 echo "user.max_user_namespaces=10000" >> /etc/sysctl.conf
 
+# Following steps are needed to 'unconfuse' systemd after being replaced by
+# an upstream version
+# 1) user-0.slice get stuck for a while, which breaks ssh connections
+# 2) systemd-reboot.service has an incompatible format, so daemon-reexec
+#    is needed to fix this
+SYSTEMD_LOG_LEVEL=debug systemctl restart user-0.slice
+systemctl status user-0.slice
+SYSTEMD_LOG_LEVEL=debug systemctl daemon-reexec
+
 echo "-----------------------------"
 echo "- REBOOT THE MACHINE BEFORE -"
 echo "-         CONTINUING        -"

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -22,49 +22,15 @@ trap at_exit EXIT
 set -e -u
 set -o pipefail
 
-COPR_REPO="https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci/repo/epel-7/mrc0mmand-systemd-centos-ci-epel-7.repo"
-COPR_REPO_PATH="/etc/yum.repos.d/${COPR_REPO##*/}"
+ADDITIONAL_DEPS=(libasan libubsan make net-tools qemu-kvm quota strace)
 
-# Enable necessary repositories and install required packages
-#   - enable custom Copr repo with newer versions of certain packages (necessary
-#     to sucessfully compile upstream systemd on CentOS)
-#   - enable EPEL repo for additional dependencies
-#   - update current system
-#   - install python 3.6 (required by meson) and install meson + other build deps
-curl "$COPR_REPO" -o "$COPR_REPO_PATH"
-# Add a copr repo mirror
-# Note: if a URL starts on a new line, it MUST begin with leading spaces,
-#       otherwise it will be ignored
-sed -i '/baseurl=/a\    http://artifacts.ci.centos.org/systemd/mrc0mmand-systemd-centos-ci/' "$COPR_REPO_PATH"
-sed -i '/gpgkey=/d' "$COPR_REPO_PATH"
-sed -i 's/skip_if_unavailable=True/skip_if_unavailable=False/' "$COPR_REPO_PATH"
-# As the gpgkey directive doesn't support mirrors, let's install the GPG key manually
-if ! rpm --import https://copr-be.cloud.fedoraproject.org/results/mrc0mmand/systemd-centos-ci/pubkey.gpg; then
-    rpm --import http://artifacts.ci.centos.org/systemd/mrc0mmand-systemd-centos-ci/pubkey.gpg
-fi
-yum -q -y install epel-release yum-utils gdb
-yum-config-manager -q --enable epel
-yum -q -y update
-yum -q -y install busybox dnsmasq e2fsprogs gcc-c++ libasan libbpf-devel nc net-tools ninja-build \
-                  pcre2-devel python36 python-lxml qemu-kvm quota strace systemd-ci-environment
-python3.6 -m ensurepip
-python3.6 -m pip install meson
-
-# python36 package doesn't create the python3 symlink
-rm -f /usr/bin/python3
-ln -s "$(which python3.6)" /usr/bin/python3
-
-# Build and install dracut from upstream
-(
-    test -e dracut && rm -rf dracut
-    git clone git://git.kernel.org/pub/scm/boot/dracut/dracut.git
-    pushd dracut || { echo >&2 "Can't pushd to dracut"; exit 1; }
-    git checkout 046
-    ./configure --disable-documentation
-    make -j $(nproc)
-    make install
-    popd
-) 2>&1 | tee "$LOGDIR/dracut-build.log"
+# Install and enable EPEL
+dnf -q -y install epel-release dnf-utils "${ADDITIONAL_DEPS[@]}"
+dnf config-manager -q --enable epel
+# Upgrade the machine to get the most recent environment
+dnf -y upgrade
+# Install systemd's build dependencies
+dnf -q -y --enablerepo "PowerTools" builddep systemd
 
 # Fetch the upstream systemd repo
 test -e systemd && rm -rf systemd
@@ -132,10 +98,6 @@ ninja-build -C build install
     make -C test/TEST-01-BASIC clean setup run clean-again
 ) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
 
-# Readahead is dead in systemd upstream
-rm -f /usr/lib/systemd/system/systemd-readahead-done.service
-popd
-
 # The systemd testsuite uses the ext4 filesystem for QEMU virtual machines.
 # However, the ext4 module is not included in initramfs by default, because
 # CentOS uses xfs as the default filesystem
@@ -151,7 +113,8 @@ fi
 
 # Set user_namespace.enable=1 (needed for systemd-nspawn -U to work correctly)
 grubby --args="user_namespace.enable=1" --update-kernel="$(grubby --default-kernel)"
-grep "user_namespace.enable=1" /boot/grub2/grub.cfg
+# grub on RHEL 8 uses BLS
+grep -r "user_namespace.enable=1" /boot/loader/entries/
 echo "user.max_user_namespaces=10000" >> /etc/sysctl.conf
 
 echo "-----------------------------"

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -31,8 +31,10 @@ if [[ $(cat /proc/sys/user/max_user_namespaces) -le 0 ]]; then
 fi
 
 # Install test dependencies
+# kernel-modules-extra is necessary for L2P, QDisc, and other modules required
+# by the systemd-networkd testsuite
 exectask "dnf-depinstall" \
-    "dnf -y install dnsmasq e2fsprogs nc net-tools qemu-kvm quota socat strace wget"
+    "dnf -y install dnsmasq e2fsprogs iproute-tc kernel-modules-extra nc net-tools qemu-kvm quota socat strace wget"
 
 # As busybox is not shipped in RHEL 8/CentOS 8 anymore, we need to get it
 # using a different way. Needed by TEST-13-NSPAWN-SMOKE

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -31,8 +31,13 @@ if [[ $(cat /proc/sys/user/max_user_namespaces) -le 0 ]]; then
 fi
 
 # Install test dependencies
-exectask "yum-depinstall" \
-    "yum -y install net-tools strace nc busybox e2fsprogs quota dnsmasq qemu-kvm socat"
+exectask "dnf-depinstall" \
+    "dnf -y install dnsmasq e2fsprogs nc net-tools qemu-kvm quota socat strace wget"
+
+# As busybox is not shipped in RHEL 8/CentOS 8 anymore, we need to get it
+# using a different way. Needed by TEST-13-NSPAWN-SMOKE
+exectask "install-busybox" \
+    "wget -O /bin/busybox https://www.busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-x86_64 && chmod +x /bin/busybox"
 
 set +e
 

--- a/jenkins/runners/systemd-pr-build.sh
+++ b/jenkins/runners/systemd-pr-build.sh
@@ -42,4 +42,4 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py $ARGS
+./agent-control.py --version 8 $ARGS


### PR DESCRIPTION
This will help with several things, especially:
 - drop the plethora of CentOS 7 vs upstream systemd workarounds, like
   the custom Copr repo with various *mangled* dependencies
 - support systemd-homed (see: systemd/systemd#14096)
 - run more tests which depend on newer kernel's features