### PR TITLE
agent: disable systemd-homed in the CentOS 7 upstream job

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -95,6 +95,7 @@ systemctl disable firewalld
                 --buildtype=debug \
                 --optimization=1 \
                 --werror \
+                -Dhomed=false \
                 -Dslow-tests=true \
                 -Dtests=unsafe \
                 -Dinstall-tests=true \


### PR DESCRIPTION
systemd-homed requires (among others) libfdisk, which is not present on
CentOS 7. As it's already being tested by the Arch Linux job, let's skip
it here.