### PR TITLE
vagrant: configure nfsd explicitly

### DIFF
--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -61,3 +61,8 @@ fi
 
 vagrant --version
 vagrant plugin list
+
+# Configure NFS for Vagrant's shared folders
+$PKG_MAN -y install nfs-utils
+systemctl enable --now nfs-server
+systemctl status nfs-server


### PR DESCRIPTION
As Vagrant uses NFS for its shared folders, we need a working nfsd on
the host machine. So far we always left the responsibility on the
provisioner, but experience showed the nfsd is not always up when we
need it. Let's enable & start it explicitly to make sure we have a
working nfsd before playing around with Vagrant.