### PR TITLE
vagrant: install & setup NTP (chrony) on both host & guest machines

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -66,6 +66,11 @@ Vagrant.configure("2") do |config|
     pacman --needed --noconfirm -S coreutils busybox dhclient dhcpcd diffutils dnsmasq e2fsprogs \
         gdb inetutils net-tools openbsd-netcat qemu rsync socat strace vi wireguard-arch
 
+    # Configure NTP (chronyd)
+    pacman --needed --noconfirm -S chrony
+    systemctl enable --now chronyd
+    systemctl status chronyd
+
     # Compile & install libbpf-next
     pacman --needed --noconfirm -S elfutils libelf
     git clone https://github.com/libbpf/libbpf libbpf

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -36,6 +36,15 @@ else
     echo "[vagrant-setup] No KVM module found, can't setup nested KVM"
 fi
 
+# Configure NTP (chronyd)
+if ! rpm -q chrony; then
+    $PKG_MAN -y install chrony
+fi
+
+systemctl enable --now chronyd
+systemctl status chronyd
+
+# Configure Vagrant
 if ! vagrant version 2>/dev/null; then
     # Install Vagrant
     $PKG_MAN -y install "$VAGRANT_PKG_URL"


### PR DESCRIPTION
This should, theoretically & hopefully, fix the race condition, where
systemd compilation on NFS inside the Vagrant VM sporadically dies with:

archlinux_systemd_ci: /usr/bin/ld: error: /build/build/src/udev/libudev.so.1: file too short