### PR TITLE
Use -Dinstall-tests=true in more places

### DIFF
--- a/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
@@ -35,6 +35,7 @@ meson build \
       -Dtests=unsafe \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d \
       -Dman=false \
+      -Dinstall-tests=true \
       -Db_sanitize=address,undefined \
       -Db_lundef=false # See https://github.com/mesonbuild/meson/issues/764
 ninja -C build

--- a/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
@@ -30,6 +30,7 @@ meson build \
       -Dtests=unsafe \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d \
       -Dman=false \
+      -Dinstall-tests=true \
       -Db_sanitize=address,undefined
 ninja -C build
 


### PR DESCRIPTION
This is for https://github.com/systemd/systemd/pull/14338.
Now all TEST-* tests need builds with -Dinstall-tests=true.