### PR TITLE
agent/rhel8: temporarily disable CodeReady repo

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -30,7 +30,9 @@ dnf config-manager --enable epel
 # Upgrade the machine to get the most recent environment
 dnf -y upgrade
 # Install systemd's build dependencies
-dnf -y --enablerepo "PowerTools" builddep systemd
+# FIXME: temporarily disable CodeReady repo, which contains package conflict
+#   > Problem: libblkid-2.32.1-17.el8.i686 has inferior architecture
+dnf -y --enablerepo "PowerTools" --disablerepo=cr builddep systemd
 
 # Fetch the systemd repo
 test -e systemd && rm -rf systemd


### PR DESCRIPTION
Currently the repository contains a package conflict, which breaks the
installation of systemd build dependencies:

```
 # dnf builddep --enablerepo=PowerTools  -y systemd
 enabling AppStream-source repository
 enabling BaseOS-source repository
 enabling extras-source repository
 enabling epel-modular-source repository
 enabling epel-source repository
 Last metadata expiration check: 0:00:38 ago on Mon 13 Jan 2020 04:21:26 PM GMT.
 Package gettext-0.19.8.1-17.el8.x86_64 is already installed.
 Package git-2.18.1-4.el8.x86_64 is already installed.
 Package gawk-4.2.1-1.el8.x86_64 is already installed.
 Package xz-5.2.4-3.el8.x86_64 is already installed.
 Package firewalld-filesystem-0.7.0-5.el8.noarch is already installed.
 Error:
  Problem: libblkid-2.32.1-17.el8.i686 has inferior architecture
   - package libblkid-devel-2.32.1-17.el8.x86_64 requires libblkid = 2.32.1-17.el8, but none of the providers can be installed
   - cannot install both libblkid-2.32.1-8.el8.x86_64 and libblkid-2.32.1-17.el8.x86_64
   - cannot install both libblkid-2.32.1-17.el8.x86_64 and libblkid-2.32.1-8.el8.x86_64
   - package libmount-devel-2.32.1-8.el8.x86_64 requires libmount = 2.32.1-8.el8, but none of the providers can be installed
   - package libmount-2.32.1-8.el8.i686 requires libblkid = 2.32.1-8.el8, but none of the providers can be installed
   - package libmount-2.32.1-8.el8.x86_64 requires libblkid = 2.32.1-8.el8, but none of the providers can be installed
   - libblkid-2.32.1-8.el8.i686 has inferior architecture
   - cannot install the best candidate for the job
```

See: https://github.com/systemd-rhel/rhel-8/pull/57