### PR TITLE
Revert "agent: temporary hotfix for broken internal mirrorlist on Cen…

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -411,10 +411,6 @@ if __name__ == "__main__":
         artifacts_dir = tempfile.mkdtemp(prefix="artifacts_", dir=".")
         ac.artifacts_storage = artifacts_dir
 
-        # FIXME: temporary workaround for broken internal mirrorlist
-        if args.version == "8":
-            ac.execute_remote_command(node, "sed -i -e '/^mirrorlist/s/^/#/g' -e '/^#baseurl/s/^#//g'  /etc/yum.repos.d/*.repo")
-
         # Let's differentiate between CentOS <= 7 (yum) and CentOS >= 8 (dnf)
         pkg_man = "yum" if args.version in ["6", "7"] else "dnf"
         # Clean dnf/yum caches to drop stale metadata and prevent unexpected


### PR DESCRIPTION
…tOS 8"

This reverts commit a9f90439032b5e52cc4d5af3fe1208d115220dca.

According to the CentOS Infra guys the regression in the mirrorlist
script has been resolved, so this workaround is not needed anymore.

Fixes: #212