### PR TITLE
vagrant: pin util-linux & libutil-linux to 2.34

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -101,5 +101,12 @@ EOF
   # See: https://github.com/systemd/systemd/issues/14548
   pacman --noconfirm -U https://archive.archlinux.org/packages/l/libcap/libcap-2.28-1-x86_64.pkg.tar.xz
 
+  # FIXME
+  # Temporarily pin util-linux & libutil-linux to 2.34 until fixed 2.35 version
+  # is released
+  # See: https://github.com/systemd/systemd/pull/14677#issuecomment-579200696
+  pacman --noconfirm -U https://archive.archlinux.org/packages/l/libutil-linux/libutil-linux-2.34-8-x86_64.pkg.tar.xz \
+                        https://archive.archlinux.org/packages/u/util-linux/util-linux-2.34-8-x86_64.pkg.tar.xz
+
   SHELL
 end


### PR DESCRIPTION
Version 2.35 contains a double-free issue which was already fixed in the
latest master[0]. Let's temporarily downgrade *util-linux to 2.34 until
the fixed version is released to Arch repositories.

See: https://github.com/systemd/systemd/pull/14677#issuecomment-579200696

[0] https://github.com/karelzak/util-linux/commit/caa37b6e18fdcd29e57ab82fe1d54b293fccbf3b