### PR TITLE
vagrant: unpin util-linux

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -101,12 +101,5 @@ EOF
   # See: https://github.com/systemd/systemd/issues/14548
   pacman --noconfirm -U https://archive.archlinux.org/packages/l/libcap/libcap-2.28-1-x86_64.pkg.tar.xz
 
-  # FIXME
-  # Temporarily pin util-linux & libutil-linux to 2.34 until fixed 2.35 version
-  # is released
-  # See: https://github.com/systemd/systemd/pull/14677#issuecomment-579200696
-  pacman --noconfirm -U https://archive.archlinux.org/packages/l/libutil-linux/libutil-linux-2.34-8-x86_64.pkg.tar.xz \
-                        https://archive.archlinux.org/packages/u/util-linux/util-linux-2.34-8-x86_64.pkg.tar.xz
-
   SHELL
 end


### PR DESCRIPTION
A new version of util-linux ([2.35.1](https://github.com/karelzak/util-linux/releases/tag/v2.35.1)) has been released which should address the double-free issue. ~~Let's check that before reverting #215 (and thus fixing #216).~~ Seems to work as expected, let's revert the workaround.