### PR TITLE
Revert "vagrant: temporarily pin libcap to v2.28"

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -96,10 +96,5 @@ Vagrant.configure("2") do |config|
     Unmanaged=yes
 EOF
 
-  # FIXME
-  # Temporarily pin libcap to 2.28
-  # See: https://github.com/systemd/systemd/issues/14548
-  pacman --noconfirm -U https://archive.archlinux.org/packages/l/libcap/libcap-2.28-1-x86_64.pkg.tar.xz
-
   SHELL
 end


### PR DESCRIPTION
This reverts commit 0397444f18634fff38a0bbe6f0c54840208feec8.

Fixes: #208
Fixed by: systemd/systemd#14768