### PR TITLE
vagrant: "fix" the clang build and use it as a default for PR testing

### DIFF
--- a/jenkins/runners/systemd-cron-build.sh
+++ b/jenkins/runners/systemd-cron-build.sh
@@ -36,5 +36,5 @@ ARGS=
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
-./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS
+./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
+#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
+++ b/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
@@ -52,5 +52,5 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
-#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS
+#./agent-control.py --no-index --vagrant arch-sanitizers-gcc $ARGS
+./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
@@ -29,7 +29,7 @@ export CXXFLAGS="-shared-libasan"
 
 meson build \
       --werror \
-      -Dc_args='-fno-omit-frame-pointer -ftrapv' \
+      -Dc_args='-Og -fno-omit-frame-pointer -ftrapv' \
       --buildtype=debug \
       --optimization=g \
       -Dtests=unsafe \


### PR DESCRIPTION
Passing `-Og` using `--optimization=g` doesn't work in combination with
clang, so let's do it this way, until it's fixed.

Also, this masks another issue, where systemd fails to build with `-O0`,
which should be dealt with later.

See:
 - mesonbuild/meson#6619
 - systemd/systemd#14865