### PR TITLE
vagrant: check and possibly load the  nfs & nfsd kernel modules

### DIFF
--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -73,5 +73,8 @@ vagrant plugin list
 
 # Configure NFS for Vagrant's shared folders
 $PKG_MAN -y install nfs-utils
-systemctl enable --now nfs-server
+lsmod | grep -E '^nfs$' || modprobe -v nfs
+lsmod | grep -E '^nfsd$' || modprobe -v nfsd
+systemctl enable  nfs-server
+systemctl restart nfs-server
 systemctl status nfs-server


### PR DESCRIPTION
Beef up the nfsd check once again, as the race during Vagrant startup is
still there even though the nfsd seems to be running fine:

```
It appears your machine doesn't support NFS, or there is not an
adapter to enable NFS on this machine for Vagrant. Please verify
that `nfsd` is installed on your machine, and try again. If you're
on Windows, NFS isn't supported. If the problem persists, please
contact Vagrant support.
```