### PR TITLE
agent/vagrant: make the parallelization temporarily conditioned

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -35,6 +35,15 @@ set +e
 ### TEST PHASE ###
 pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
 
+# Make the parallelization temporarily conditional
+# See: https://github.com/systemd/systemd/pull/14338
+if grep "IMAGE_NAME=" test/test-functions; then
+    PARALLELIZE=0
+    OPTIMAL_QEMU_SMP=$(nproc)
+else
+    PARALLELIZE=1
+fi
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 
@@ -95,11 +104,16 @@ for t in test/TEST-??-*; do
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 
-    exectask_p "${t##*/}" "make -C $t clean setup run && touch $TESTDIR/pass"
+    if [[ $PARALLELIZE -ne 0 ]]; then
+        exectask_p "${t##*/}" "make -C $t clean setup run && touch $TESTDIR/pass"
+    else
+        exectask "${t##*/}" "make -C $t clean setup run && touch $TESTDIR/pass"
+    fi
+
 done
 
 # Wait for remaining running tasks
-exectask_p_finish
+[[ $PARALLELIZE -ne 0 ]] && exectask_p_finish
 
 # Save journals created by integration tests
 for t in test/TEST-??-*; do


### PR DESCRIPTION
The test suite is being rewritten in systemd/systemd#14338 which should
speed things up significantly. However, it also breaks the current
parallelization optimizations done by test runners in CI, so let's make
them temporarily conditional for branches which contain the new code.