### PR TITLE
vagrant: move compilation away from NFS

### DIFF
--- a/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-set -e
+set -eu
 
 whoami
 uname -a
 
 # The custom CentOS CI box should be updated and provide necessary
 # build & test dependencies
+
+# Let's make the $BUILD_DIR for meson reside outside of the NFS volume mounted
+# under /build to avoid certain race conditions, like:
+# /usr/bin/ld: error: /build/build/src/udev/libudev.so.1: file too short
+# The same path must be exported in the respective tests scripts (vagrant-test.sh,
+# etc.) so the unit & integration tests can find the compiled binaries
+# Note: avoid using /tmp or /var/tmp, as certain tests use binaries from the
+#       buildir in combination with PrivateTmp=true
+export BUILD_DIR="${BUILD_DIR:-/systemd-meson-build}"
 
 # Use systemd repo path specified by SYSTEMD_ROOT
 pushd /build
@@ -18,11 +27,11 @@ cat <(echo "# CPUINFO") /proc/cpuinfo >> vagrant-arch-sanitizers-gcc-osinfo.txt
 cat <(echo "# MEMINFO") /proc/meminfo >> vagrant-arch-sanitizers-gcc-osinfo.txt
 cat <(echo "# VERSION") /proc/version >> vagrant-arch-sanitizers-gcc-osinfo.txt
 
-rm -fr build
+rm -fr "$BUILD_DIR"
 # Build phase
 # Compile systemd with the Address Sanitizer (ASan) and Undefined Behavior
 # Sanitizer (UBSan)
-meson build \
+meson "$BUILD_DIR" \
       --werror \
       -Dc_args='-fno-omit-frame-pointer -ftrapv' \
       --buildtype=debug \
@@ -32,7 +41,7 @@ meson build \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d \
       -Dman=false \
       -Db_sanitize=address,undefined
-ninja -C build
+ninja -C "$BUILD_DIR"
 
 # Manually install upstream D-Bus config file for org.freedesktop.network1
 # so systemd-networkd testsuite can use potentially new/updated methods
@@ -41,7 +50,7 @@ cp -fv src/network/org.freedesktop.network1.conf /usr/share/dbus-1/system.d/
 # Manually install upstream systemd-networkd* service unit files in case a PR
 # introduces a change in them
 # See: https://github.com/systemd/systemd/pull/14415#issuecomment-579307925
-cp -fv build/units/systemd-networkd.service /usr/lib/systemd/system/systemd-networkd.service
-cp -fv build/units/systemd-networkd-wait-online.service /usr/lib/systemd/system/systemd-networkd-wait-online.service
+cp -fv "$BUILD_DIR/units/systemd-networkd.service" /usr/lib/systemd/system/systemd-networkd.service
+cp -fv "$BUILD_DIR/units/systemd-networkd-wait-online.service" /usr/lib/systemd/system/systemd-networkd-wait-online.service
 
 popd

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -8,6 +8,10 @@
 
 DISTRO="${1:-unspecified}"
 SCRIPT_DIR="$(dirname $0)"
+# This variable is automagically consumed by the "framework" for integration tests
+# See respective bootstrap script under vagrant/bootstrap_scripts/ for reasoning
+export BUILD_DIR="${BUILD_DIR:-/systemd-meson-build}"
+
 # Following scripts are copied from the systemd-centos-ci/common directory
 # by vagrant-build.sh
 . "$SCRIPT_DIR/task-control.sh" "vagrant-$DISTRO-testsuite" || exit 1
@@ -35,7 +39,7 @@ fi
 echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
 
 # Run the internal unit tests (make check)
-exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
+exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 
 ## Integration test suite ##
 # Prepare a custom-tailored initrd image (with the systemd module included).
@@ -172,7 +176,7 @@ if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
     done
 fi
 
-[[ -d /build/build/meson-logs ]] && cp -r /build/build/meson-logs "$LOGDIR"
+[[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
 exit $FAILED


### PR DESCRIPTION
The NFS volume we mount into the Vagrant VM with the systemd repository
has been giving me a headache for the past several months. Basically,
some of the Vagrant jobs (~5% of them) die due to the following issue:

```
/usr/bin/ld: error: /build/build/src/udev/libudev.so.1: file too short
collect2: error: ld returned 1 exit status
```

Apparently, this has to do something with desynchronized file timestamps
between the host and the guest, but even after installing and
configuring an NTP server on both sides the issue never went completely
away (see #201).

Let's just do the heavy lifting (compilation) on the internal VM storage
and see how it fares.

Fixes: #199