### PR TITLE
vagrant: wireguard is now part of the default kernel package

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -64,7 +64,7 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S coreutils busybox dhclient dhcpcd diffutils dnsmasq e2fsprogs \
-        gdb inetutils net-tools openbsd-netcat qemu rsync socat strace vi wireguard-arch
+        gdb inetutils net-tools openbsd-netcat qemu rsync socat strace vi
 
     # Configure NTP (chronyd)
     pacman --needed --noconfirm -S chrony


### PR DESCRIPTION
See: https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/linux&id=3734fe98a51ca7e776052cdabc80be9885b7d40d