### PR TITLE
common: introduce `in_set` helper function

### DIFF
--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 . "$(dirname "$0")/../common/task-control.sh" "testsuite-logs-rhel7" || exit 1
+. "$(dirname "$0")/../common/utils.sh" || exit 1
 
 # EXIT signal handler
 function at_exit {
@@ -37,7 +38,7 @@ SKIP_LIST=()
 qemu-kvm --version
 
 for t in test/TEST-??-*; do
-    if [[ ${#SKIP_LIST[@]} -ne 0 && " ${SKIP_LIST[@]} " =~ " $t " ]]; then
+    if [[ ${#SKIP_LIST[@]} -ne 0 ]] && in_set "$t" "${SKIP_LIST[@]}"; then
         echo -e "\n[SKIP] Skipping test $t"
         continue
     fi

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 . "$(dirname "$0")/../common/task-control.sh" "testsuite-logs-rhel8" || exit 1
+. "$(dirname "$0")/../common/utils.sh" || exit 1
 
 # EXIT signal handler
 function at_exit {
@@ -57,7 +58,7 @@ qemu-kvm --version
 sed -i 's/is_v2_supported=yes/is_v2_supported=no/g' test/TEST-13-NSPAWN-SMOKE/test.sh
 
 for t in test/TEST-??-*; do
-    if [[ ${#SKIP_LIST[@]} -ne 0 && " ${SKIP_LIST[@]} " =~ " $t " ]]; then
+    if [[ ${#SKIP_LIST[@]} -ne 0 ]] && in_set "$t" "${SKIP_LIST[@]}"; then
         echo -e "\n[SKIP] Skipping test $t"
         continue
     fi

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -79,7 +79,7 @@ cp -fv "/boot/initramfs-$(uname -r).img" "$INITRD"
 dracut -o multipath --rebuild "$INITRD"
 
 for t in test/TEST-??-*; do
-    if [[ ${#SKIP_LIST[@]} -ne 0 && " ${SKIP_LIST[@]} " =~ " $t " ]]; then
+    if [[ ${#SKIP_LIST[@]} -ne 0 ]] && in_set "$t" "${SKIP_LIST[@]}"; then
         echo -e "\n[SKIP] Skipping test $t"
         continue
     fi

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -115,12 +115,20 @@ done
 # Wait for remaining running tasks
 [[ $PARALLELIZE -ne 0 ]] && exectask_p_finish
 
+COREDUMPCTL_SKIP=(
+    # This test intentionally kills several processes using SIGABRT, thus generating
+    # cores which we're not interested in
+    "test/TEST-48-UDEV-EVENT-TIMEOUT"
+)
+
 # Save journals created by integration tests
 for t in test/TEST-??-*; do
     testdir="/var/tmp/systemd-test-${t##*/}"
     if [[ -f "$testdir/system.journal" ]]; then
-        # Attempt to collect coredumps from test-specific journals as well
-        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/'"
+        if ! in_set "$t" "${COREDUMPCTL_SKIP[@]}"; then
+            # Attempt to collect coredumps from test-specific journals as well
+            exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/'"
+        fi
         # Keep the journal files only if the associated test case failed
         if [[ ! -f "$testdir/pass" ]]; then
             rsync -aq "$testdir/system.journal" "$LOGDIR/${t##*/}/"

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -8,6 +8,39 @@ __COREDUMPCTL_TS=""
 _log() { echo "[${FUNCNAME[1]}] $1"; }
 _err() { echo >&2 "[${FUNCNAME[1]}] $1"; }
 
+# Checks if the first argument is in a set consisting of the rest of the arguments
+#
+# Works around the limitation of not being able to pass arrays as arguments in bash
+# (well, there *are* ways, but not convenient ones). It, of course, doesn't work
+# for _extra_ large arrays (but that's not a case we need, at least for now).
+# Example usage:
+#   my_array=("one", "two", "three")
+#   if ! in_set "five" "${my_array[@]}"; then...
+#
+# Arguments:
+#   $1    - element to check
+#   $2-$n - "set" of elements
+#
+# Returns:
+#   0 on success, 1 otherwise
+in_set() {
+    if [[ $# -lt 2 ]]; then
+        _err "Not enough arguments"
+        return 1
+    fi
+
+    local NEEDLE="$1"
+    shift
+
+    for _elem in "$@"; do
+        if [[ "$_elem" == "$NEEDLE" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 # Checkout to the requsted branch:
 #   1) if pr:XXX where XXX is a pull request ID is passed to the script,
 #      the corresponding branch for this PR is be checked out

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -123,12 +123,20 @@ for t in "${SERIALIZED_TASKS[@]}"; do
     exectask "${t##*/}" "make -C $t clean setup run && touch $TESTDIR/pass"
 done
 
+COREDUMPCTL_SKIP=(
+    # This test intentionally kills several processes using SIGABRT, thus generating
+    # cores which we're not interested in
+    "test/TEST-48-UDEV-EVENT-TIMEOUT"
+)
+
 # Save journals created by integration tests
 for t in test/TEST-??-*; do
     testdir="/var/tmp/systemd-test-${t##*/}"
     if [[ -f "$testdir/system.journal" ]]; then
-        # Attempt to collect coredumps from test-specific journals as well
-        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/'"
+        if ! in_set "$t" "${COREDUMPCTL_SKIP[@]}"; then
+            # Attempt to collect coredumps from test-specific journals as well
+            exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/'"
+        fi
         # Keep the journal files only if the associated test case failed
         if [[ ! -f "$testdir/pass" ]]; then
             rsync -aq "$testdir/system.journal" "$LOGDIR/${t##*/}/"

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -62,7 +62,7 @@ SKIP_LIST=(
 )
 
 for t in test/TEST-??-*; do
-    if [[ ${#SKIP_LIST[@]} -ne 0 && " ${SKIP_LIST[@]} " =~ " $t " ]]; then
+    if [[ ${#SKIP_LIST[@]} -ne 0 ]] && in_set "$t" "${SKIP_LIST[@]}"; then
         echo -e "\n[SKIP] Skipping test $t"
         continue
     fi


### PR DESCRIPTION
Checking for elements in array using the regex "solution" is quite ugly
and shellcheck doesn't like it at all. Let's introduce a new helper
which should make it easier & prettier

Also, skip the coredump check on TEST-48-UDEV-EVENT-TIMEOUT,
as it intentionally generates a few coredumps we're not interested in.
