### PR TITLE
vagrant: work around the LLVM ASan issue & switch the cron job to clang

### DIFF
--- a/jenkins/runners/systemd-cron-build.sh
+++ b/jenkins/runners/systemd-cron-build.sh
@@ -36,5 +36,5 @@ ARGS=
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
-#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS
+#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
+./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -130,12 +130,6 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         test/TEST-46-HOMED   # systemd-homed & friends
     )
 
-    # FIXME: temporary workaround for systemd/systemd#14338
-    # TEST-45-REPART has been moved to a unit-test, so it's run as part
-    # of `meson test` above
-    ! grep "IMAGE_NAME=" test/test-functions && INTEGRATION_TESTS+=(test/TEST-45-REPART)
-
-
     for t in "${INTEGRATION_TESTS[@]}"; do
         # Set the test dir to something predictable so we can refer to it later
         export TESTDIR="/var/tmp/systemd-test-${t##*/}"

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -127,8 +127,14 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
     ## be somewhat sure the 'base' systemd components work).
     INTEGRATION_TESTS=(
         test/TEST-04-JOURNAL # systemd-journald
-        test/TEST-46-HOMED   # systemd-homed & friends
     )
+
+    # FIXME: LLVM 10 has an interesting issue, which breaks library detection
+    # when -fsanitize=address is used, causing ASan to segfault during
+    # TEST-46-HOMED. Let's disable it for now (only for LLVM runs) until it's
+    # fixed, so we can still use the rest of the LLVM run.
+    # See: https://bugzilla.redhat.com/show_bug.cgi?id=1827338
+    [[ -z "$_clang_asan_rt_name" ]] && INTEGRATION_TESTS+=(test/TEST-46-HOMED) # systemd-homed & friends
 
     for t in "${INTEGRATION_TESTS[@]}"; do
         # Set the test dir to something predictable so we can refer to it later


### PR DESCRIPTION
Since dfe84a2d86b29eee95a38de416c43efc6ade8eb5 the LLVM/clang job has been disabled completely, as [BZ#1827338](https://bugzilla.redhat.com/show_bug.cgi?id=1827338) breaks `TEST-46-HOMED` (and possibly other things) under ASan.

Until it's fixed let's disable the problematic test so we can *salvage* the rest of the run and use it at least in the Jenkins cron job, since it sometimes discovers issues which gcc misses.