### PR TITLE
vagrant: pin Arch repos to 2020-04-29 to stick with kernel 5.6.7

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -53,7 +53,16 @@ Vagrant.configure("2") do |config|
     pacman-key --populate archlinux
     pacman --noconfirm -S archlinux-keyring
     # Upgrade the system
-    pacman --noconfirm -Syu
+    #pacman --noconfirm -Syu
+
+    # TEMPORARY WORKAROUND #
+    # Pin all repositories to a snapshot from 2020-04-29 to stick with a system
+    # with kernel 5.6.7
+    # See https://github.com/systemd/systemd/pull/15682 for more details
+    # Uncomment the pacman line above when dropping this workaround
+    echo 'Server=https://archive.archlinux.org/repos/2020/04/29/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+    pacman --noconfirm -Syyuu
+
     # Install build dependencies
     # Package groups: base, base-devel
     pacman --needed --noconfirm -S base base-devel acl audit bash-completion clang compiler-rt docbook-xsl ethtool \


### PR DESCRIPTION
Kernels 5.6.8+ seem to have a bug in loopdev handling, which completely
breaks the integration test suite.

See: https://github.com/systemd/systemd/pull/15682