### PR TITLE
Revert "vagrant: pin Arch repos to 2020-04-29 to stick with kernel 5.…

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -53,16 +53,7 @@ Vagrant.configure("2") do |config|
     pacman-key --populate archlinux
     pacman --noconfirm -S archlinux-keyring
     # Upgrade the system
-    #pacman --noconfirm -Syu
-
-    # TEMPORARY WORKAROUND #
-    # Pin all repositories to a snapshot from 2020-04-29 to stick with a system
-    # with kernel 5.6.7
-    # See https://github.com/systemd/systemd/pull/15682 for more details
-    # Uncomment the pacman line above when dropping this workaround
-    echo 'Server=https://archive.archlinux.org/repos/2020/04/29/$repo/os/$arch' > /etc/pacman.d/mirrorlist
-    pacman --noconfirm -Syyuu
-
+    pacman --noconfirm -Syu
     # Install build dependencies
     # Package groups: base, base-devel
     pacman --needed --noconfirm -S base base-devel acl audit bash-completion clang compiler-rt docbook-xsl ethtool \


### PR DESCRIPTION
…6.7"

This reverts commit 2c4249cc1a945d64ae807b3da5f9400f3630891e.

The loopdev handling issue has been fixed in 5.6.11, so the pin is no
longer necessary.

Fixes: #250