### PR TITLE
vagrant: use LDFLAGS="-Wl,--no-as-needed" in sanitizer runs

### DIFF
--- a/jenkins/runners/systemd-cron-build.sh
+++ b/jenkins/runners/systemd-cron-build.sh
@@ -36,5 +36,5 @@ ARGS=
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
-./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS
+./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
+#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
+++ b/jenkins/runners/systemd-pr-build-vagrant-sanitizers.sh
@@ -52,5 +52,5 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-gcc $ARGS
-#./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS
+#./agent-control.py --no-index --vagrant arch-sanitizers-gcc $ARGS
+./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang $ARGS

--- a/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
@@ -35,6 +35,19 @@ export CC=clang
 export CXX=clang++
 export CFLAGS="-shared-libasan"
 export CXXFLAGS="-shared-libasan"
+# FIXME
+# Since version 10, both gcc and clang started to ignore certain linker errors
+# when compiling with -fsanitize=address. This eventually leads up to -lcrypt
+# not being correctly propagated, but the fact is masked by the aforementioned
+# issue. However, when the binary attempts to load a symbol from the libcrypt
+# binary, it crashes since it's not linked correctly against it.
+# Negating the -Wl,--as-needed used by default by -Wl,--no-as-needed seems to
+# help in this case.
+#
+# See:
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1827338#c3
+#   https://github.com/systemd/systemd-centos-ci/issues/247
+export LDFLAGS="-Wl,--no-as-needed"
 
 meson "$BUILD_DIR" \
       --werror \

--- a/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
@@ -31,6 +31,21 @@ rm -fr "$BUILD_DIR"
 # Build phase
 # Compile systemd with the Address Sanitizer (ASan) and Undefined Behavior
 # Sanitizer (UBSan)
+
+# FIXME
+# Since version 10, both gcc and clang started to ignore certain linker errors
+# when compiling with -fsanitize=address. This eventually leads up to -lcrypt
+# not being correctly propagated, but the fact is masked by the aforementioned
+# issue. However, when the binary attempts to load a symbol from the libcrypt
+# binary, it crashes since it's not linked correctly against it.
+# Negating the -Wl,--as-needed used by default by -Wl,--no-as-needed seems to
+# help in this case.
+#
+# See:
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1827338#c3
+#   https://github.com/systemd/systemd-centos-ci/issues/247
+export LDFLAGS="-Wl,--no-as-needed"
+
 meson "$BUILD_DIR" \
       --werror \
       -Dc_args='-fno-omit-frame-pointer -ftrapv' \

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -127,14 +127,8 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
     ## be somewhat sure the 'base' systemd components work).
     INTEGRATION_TESTS=(
         test/TEST-04-JOURNAL # systemd-journald
+        test/TEST-46-HOMED   # systemd-homed & friends
     )
-
-    # FIXME: LLVM 10 has an interesting issue, which breaks library detection
-    # when -fsanitize=address is used, causing ASan to segfault during
-    # TEST-46-HOMED. Let's disable it for now (only for LLVM runs) until it's
-    # fixed, so we can still use the rest of the LLVM run.
-    # See: https://bugzilla.redhat.com/show_bug.cgi?id=1827338
-    [[ -z "$_clang_asan_rt_name" ]] && INTEGRATION_TESTS+=(test/TEST-46-HOMED) # systemd-homed & friends
 
     for t in "${INTEGRATION_TESTS[@]}"; do
         # Set the test dir to something predictable so we can refer to it later

--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -134,9 +134,7 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
     # TEST-46-HOMED. Let's disable it for now (only for LLVM runs) until it's
     # fixed, so we can still use the rest of the LLVM run.
     # See: https://bugzilla.redhat.com/show_bug.cgi?id=1827338
-    # FIXME#2: GCC 10 picked up the issue as well, I'll need to come up with
-    # a workaround
-    #[[ -z "$_clang_asan_rt_name" ]] && INTEGRATION_TESTS+=(test/TEST-46-HOMED) # systemd-homed & friends
+    [[ -z "$_clang_asan_rt_name" ]] && INTEGRATION_TESTS+=(test/TEST-46-HOMED) # systemd-homed & friends
 
     for t in "${INTEGRATION_TESTS[@]}"; do
         # Set the test dir to something predictable so we can refer to it later


### PR DESCRIPTION
Since version 10, both gcc and clang started to ignore certain linker errors
when compiling with -fsanitize=address. This eventually leads up to -lcrypt
not being correctly propagated, but the fact is masked by the aforementioned
issue. However, when the binary attempts to load a symbol from the libcrypt
binary, it crashes since it's not linked correctly against it.
Negating the -Wl,--as-needed used by default by -Wl,--no-as-needed seems to
help in this case.

See:
  https://bugzilla.redhat.com/show_bug.cgi?id=1827338#c3
  https://github.com/systemd/systemd-centos-ci/issues/247

/cc @evverx - this whole situation feels especially icky, hopefully I'm not missing something obvious :-)