### PR TITLE
agent/rhel8: support testing on both legacy & unified cgroups

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -349,11 +349,11 @@ if __name__ == "__main__":
             help="Architecture")
     parser.add_argument("--branch",
             help="Commit/tag/branch to checkout")
-    parser.add_argument("--ci-pr",
+    parser.add_argument("--ci-pr", metavar="PR",
             help="Pull request ID to check out (systemd-centos-ci repository)")
     parser.add_argument("--free-all-nodes", action="store_const", const=True,
             help="Free all currently provisioned nodes")
-    parser.add_argument("--free-session",
+    parser.add_argument("--free-session", metavar="SESSION_ID",
             help="Return nodes from a session back to the pool")
     parser.add_argument("--keep", action="store_const", const=True,
             help="Do not kill provisioned build host")
@@ -363,9 +363,11 @@ if __name__ == "__main__":
             help="Don't generate the artifact HTML page")
     parser.add_argument("--pr",
             help="Pull request ID to check out (systemd repository)")
-    parser.add_argument("--rhel", metavar="version", type=int,
+    parser.add_argument("--rhel", metavar="VERSION", type=int,
             help="Use RHEL downstream systemd repo")
-    parser.add_argument("--vagrant", metavar="distro-tag", type=str,
+    parser.add_argument("--rhel-bootstrap-args", metavar="ARGS", type=str,
+            help="Pass optional arguments to the RHEL bootstrap script")
+    parser.add_argument("--vagrant", metavar="DISTRO_TAG", type=str, default="",
             help="Run testing in Vagrant VMs on a distro specified by given distro tag")
     parser.add_argument("--vagrant-sync", action="store_const", const=True,
             help="Run a script which updates and rebuilds Vagrant images used by systemd CentOS CI")
@@ -402,11 +404,11 @@ if __name__ == "__main__":
 
         # Figure out a systemd branch to compile
         if args.pr:
-            branch = "pr:{}".format(args.pr)
+            remote_ref = "pr:{}".format(args.pr)
         elif args.branch:
-            branch = args.branch
+            remote_ref = args.branch
         else:
-            branch = ""
+            remote_ref = ""
 
         # Setup artifacts storage
         artifacts_dir = tempfile.mkdtemp(prefix="artifacts_", dir=".")
@@ -424,7 +426,7 @@ if __name__ == "__main__":
         ac.execute_remote_command(node, command)
 
         if args.ci_pr:
-            logging.info("PHASE 1.5: Using a custom CI repository branch (PR#{})".format(args.ci_pr))
+            logging.info("PHASE 1.5: Using a custom CI repository ref (PR#{})".format(args.ci_pr))
             command = "cd {} && git fetch -fu origin 'refs/pull/{}/merge:pr' && " \
                       "git checkout pr".format(GITHUB_CI_REPO, args.ci_pr)
             ac.execute_remote_command(node, command)
@@ -438,22 +440,22 @@ if __name__ == "__main__":
         elif args.vagrant:
             # Setup Vagrant and run the tests inside VM
             logging.info("PHASE 2: Run tests in Vagrant VMs")
-            command = "{}/vagrant/vagrant-ci-wrapper.sh {} {}".format(GITHUB_CI_REPO, args.vagrant, branch)
+            command = "{}/vagrant/vagrant-ci-wrapper.sh {} {}".format(GITHUB_CI_REPO, args.vagrant, remote_ref)
             ac.execute_remote_command(node, command, artifacts_dir="~/vagrant-logs*")
         else:
             # Run tests directly on the provisioned machine
-            logging.info("PHASE 2: Bootstrap (branch: {})".format(branch))
+            logging.info("PHASE 2: Bootstrap (ref: {})".format(remote_ref))
             if args.rhel is not None:
-                command = "{}/agent/bootstrap-rhel{}.sh {}".format(GITHUB_CI_REPO, args.rhel,branch)
+                command = "{}/agent/bootstrap-rhel{}.sh -r '{}' {}".format(GITHUB_CI_REPO, args.rhel, remote_ref, args.rhel_bootstrap_args)
             else:
-                command = "{}/agent/bootstrap.sh {}".format(GITHUB_CI_REPO, branch)
+                command = "{}/agent/bootstrap.sh {}".format(GITHUB_CI_REPO, remote_ref)
             ac.execute_remote_command(node, command, artifacts_dir="~/bootstrap-logs*")
 
             ac.reboot_node(node)
 
             logging.info("PHASE 3: Upstream testsuite")
             if args.rhel is not None:
-                command = "{}/agent/testsuite-rhel{}.sh {}".format(GITHUB_CI_REPO, args.rhel, branch)
+                command = "{}/agent/testsuite-rhel{}.sh {}".format(GITHUB_CI_REPO, args.rhel, remote_ref)
             else:
                 command = "{}/agent/testsuite.sh".format(GITHUB_CI_REPO)
             ac.execute_remote_command(node, command, artifacts_dir="~/testsuite-logs*")

--- a/agent-control.py
+++ b/agent-control.py
@@ -455,7 +455,7 @@ if __name__ == "__main__":
 
             logging.info("PHASE 3: Upstream testsuite")
             if args.rhel is not None:
-                command = "{}/agent/testsuite-rhel{}.sh {}".format(GITHUB_CI_REPO, args.rhel, remote_ref)
+                command = "{}/agent/testsuite-rhel{}.sh".format(GITHUB_CI_REPO, args.rhel)
             else:
                 command = "{}/agent/testsuite.sh".format(GITHUB_CI_REPO)
             ac.execute_remote_command(node, command, artifacts_dir="~/testsuite-logs*")

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/bash
 
-. "$(dirname "$0")/../common/task-control.sh" "testsuite-logs-rhel8" || exit 1
+# The common/utils.sh include needs to come first, as it includes definition
+# of print_cgroup_hierarchy()
 . "$(dirname "$0")/../common/utils.sh" || exit 1
+. "$(dirname "$0")/../common/task-control.sh" "testsuite-logs-$(print_cgroup_hierarchy)-rhel8" || exit 1
 
 # EXIT signal handler
 function at_exit {
@@ -14,6 +16,8 @@ trap at_exit EXIT
 ### SETUP PHASE ###
 # Exit on error in the setup phase
 set -e -u
+
+echo "Current cgroup hierarchy: $(print_cgroup_hierarchy)"
 
 # To get meaningful results from coredumps collected from integration tests
 # we need to store them in journal. This patchset is currently only in upcoming

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -270,3 +270,19 @@ coredumpctl_collect() {
 
     return 1
 }
+
+# Print the currently used cgroups hierarchy in a "human-friendly" form:
+# unified, hybrid, legacy, or unknown.
+print_cgroup_hierarchy() {
+    if [[ "$(stat -c '%T' -f /sys/fs/cgroup)" == cgroup2fs ]]; then
+        echo "unified"
+    elif [[ "$(stat -c '%T' -f /sys/fs/cgroup)" == tmpfs ]]; then
+        if [[ -d /sys/fs/cgroup/unified && "$(stat -c '%T' -f /sys/fs/cgroup/unified)" == cgroup2fs ]]; then
+            echo "hybrid"
+        else
+            echo "legacy"
+        fi
+    else
+        echo "unknown"
+    fi
+}

--- a/jenkins/runners/systemd-rhel8-pr-build.sh
+++ b/jenkins/runners/systemd-rhel8-pr-build.sh
@@ -17,9 +17,25 @@
 # for the tree binary for generating the artifact landing page)
 export PATH="/home/systemd/bin:$PATH"
 ARGS=
+TARGET_BRANCH="${ghprbTargetBranch:-master}"
+
 
 set -e
 set -o pipefail
+
+at_exit() {
+    # Correctly collect artifacts from all cron jobs and generate a nice
+    # directory structure
+    if find . -name "artifacts_*" | grep -q "."; then
+        mkdir _artifacts_all
+        mv artifacts_* _artifacts_all
+        mv _artifacts_all artifacts_all
+
+        utils/generate-index.sh artifacts_all index.html
+    fi
+}
+
+trap at_exit EXIT
 
 if [ "$ghprbPullId" ]; then
     ARGS="$ARGS --pr $ghprbPullId "
@@ -28,4 +44,12 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --version 8 --rhel 8 $ARGS
+# RHEL 8 job with legacy cgroup hierarchy
+./agent-control.py --version 8 --rhel 8 --rhel-bootstrap-args="-h legacy" $ARGS
+
+# RHEL 8 supports unified cgroups since RHEL 8.2, so ignore RHEL 8.0 and
+# RHEL 8.1 branches
+if [ "$TARGET_BRANCH" != "rhel-8.0.0" ] && [ "$TARGET_BRANCH" != "rhel-8.1.0" ]; then
+    # RHEL 8 job with unified cgroup hierarchy
+    ./agent-control.py --version 8 --rhel 8 --rhel-bootstrap-args="-h unified" $ARGS
+fi


### PR DESCRIPTION
Since RHEL 8.2 we kind of support the unified cgroup hierarchy (cgroups
v2) in addition to the legacy cgroups, so let's test both of them in
each RHEL 8 PR.