### PR TITLE
vagrant: halve the number of concurrent tasks

### DIFF
--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -54,6 +54,13 @@ if ! initialize_integration_tests "$PWD"; then
     exit 1
 fi
 
+# Time has shown that the kernel has apparently a hard time with 4 parallel VMs
+# inside of another VM, causing frequent soft/hard vCPU lockups.
+# Let's halve the amount of parallel tasks in an attempt to avoid this.
+# (This overrides variables defined in task-control.sh)
+export OPTIMAL_QEMU_SMP=4
+export MAX_QUEUE_SIZE=2
+
 # Parallelized tasks
 SKIP_LIST=(
     "test/TEST-10-ISSUE-2467"       # Serialized below

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -91,13 +91,6 @@ for t in test/TEST-??-*; do
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
-    # TODO: check if disabling nested KVM for this particular test case
-    #       helps with the unexpected test hangs
-    if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
-        unset TEST_NESTED_KVM
-        export QEMU_TIMEOUT=1200
-    fi
-
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"
 


### PR DESCRIPTION
After re-enabling the parallelization the number of test flakes
significantly rose and one of them pointed out a potential issue:

```
[ 1120.342877] watchdog: BUG: soft lockup - CPU#0 stuck for 22s! [systemd-nspawn:615]
[ 1148.342912] watchdog: BUG: soft lockup - CPU#0 stuck for 22s! [systemd-nspawn:615]
[ 1176.342872] watchdog: BUG: soft lockup - CPU#0 stuck for 22s! [systemd-nspawn:615]
qemu-system-x86_64: terminating on signal 15 from pid 105682 (timeout)
```

Let's halve the number of parallel tasks to see if the situation improves.
