### PR TITLE
agent/rhel8: drop the multipath module from testsuite's initrd

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -159,13 +159,17 @@ fi
 (
     # Ensure the initrd contains the same systemd version as the one we're
     # trying to test
-    dracut -f --filesystems ext4
+    # Also, rebuild the original initrd without the multipath module, see
+    # comments in `testsuite.sh` for the explanation
+    export INITRD="/var/tmp/ci-sanity-initramfs-$(uname -r).img"
+    cp -fv "/boot/initramfs-$(uname -r).img" "$INITRD"
+    dracut -o multipath --filesystems ext4 --rebuild "$INITRD"
 
     [[ ! -f /usr/bin/qemu-kvm ]] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
 
     ## Configure test environment
-    # Explicitly set paths to initramfs and kernel images (for QEMU tests)
-    export INITRD="/boot/initramfs-$(uname -r).img"
+    # Explicitly set paths to initramfs (see above) and kernel images
+    # (for QEMU tests)
     export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
     # Enable kernel debug output for easier debugging when something goes south
     export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console $CGROUP_KERNEL_ARGS"
@@ -175,6 +179,8 @@ fi
     export TEST_NO_NSPAWN=1
 
     make -C test/TEST-01-BASIC clean setup run clean
+
+    rm -fv "$INITRD"
 ) 2>&1 | tee "$LOGDIR/sanity-boot-check.log"
 
 # The systemd testsuite uses the ext4 filesystem for QEMU virtual machines.

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -83,6 +83,21 @@ fi
 [[ ! -f /usr/bin/qemu-kvm ]] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
 qemu-kvm --version
 
+## Generate a custom-tailored initrd for the integration tests
+# The host initrd contains multipath modules & services which are unused
+# in the integration tests and sometimes cause unexpected failures. Let's build
+# a custom initrd used solely by the integration tests
+#
+# Set a path to the custom initrd into the INITRD variable which is read by
+# the integration test suite "framework"
+export INITRD="/var/tmp/ci-initramfs-$(uname -r).img"
+# Copy over the original initrd, as we want to keep the custom installed
+# files we installed during the bootstrap phase (i.e. we want to keep the
+# command line arguments the original initrd was built with)
+cp -fv "/boot/initramfs-$(uname -r).img" "$INITRD"
+# Rebuild the original initrd without the multipath module
+dracut -o multipath --rebuild "$INITRD"
+
 for t in test/TEST-??-*; do
     if [[ ${#SKIP_LIST[@]} -ne 0 ]] && in_set "$t" "${SKIP_LIST[@]}"; then
         echo -e "[SKIP] Skipping test $t\n"
@@ -91,7 +106,7 @@ for t in test/TEST-??-*; do
 
     ## Configure test environment
     # Explicitly set paths to initramfs and kernel images (for QEMU tests)
-    export INITRD="/boot/initramfs-$(uname -r).img"
+    # See $INITRD above
     export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
     # Explicitly enable user namespaces
     export KERNEL_APPEND="user_namespace.enable=1 $CGROUP_KERNEL_ARGS"


### PR DESCRIPTION
Already done in the upstream job, but the issue is present in the RHEL 8
one as well.

See:
  * 554d394d23139fa24fd10ac0c0370d46a4ac70d7
  * d0f178328b7ef66868377c99f382969e2a4d9a84

---

Should fix the CI issue stumbled upon in https://github.com/systemd-rhel/rhel-8/pull/103.