### PR TITLE
vagrant: configure the NFS grace period

### DIFF
--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -72,9 +72,15 @@ vagrant --version
 vagrant plugin list
 
 # Configure NFS for Vagrant's shared folders
-$PKG_MAN -y install nfs-utils
+rpm -q nfs-utils || $PKG_MAN -y install nfs-utils
+systemctl stop nfs-server
+systemctl start proc-fs-nfsd.mount
 lsmod | grep -E '^nfs$' || modprobe -v nfs
 lsmod | grep -E '^nfsd$' || modprobe -v nfsd
+echo 10 > /proc/sys/fs/nfs/nlm_grace_period
+echo 10 > /proc/fs/nfsd/nfsv4gracetime
+echo 10 > /proc/fs/nfsd/nfsv4leasetime
 systemctl enable  nfs-server
 systemctl restart nfs-server
 systemctl status nfs-server
+sleep 10


### PR DESCRIPTION
Yet another attempt to mitigate the still-present NFS issue:

```
It appears your machine doesn't support NFS, or there is not an
adapter to enable NFS on this machine for Vagrant. Please verify
that `nfsd` is installed on your machine, and try again. If you're
on Windows, NFS isn't supported. If the problem persists, please
contact Vagrant support.
```

when starting VM. The rationale is that NFS server has a 90s grace
period (by default) after start during which it refuses any client
connections. Let's drop it to 5s, since we're in charge of all NFS
clients in this case, and wait for the grace period to pass, so we can
be sure the NFS server is indeed ready before trying to bring up a VM.