### PR TITLE
agent: explicitly override ConditionNeedsUpdate= to true

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -181,7 +181,13 @@ GRUBBY_ARGS=(
     # it early in the boot process to properly execute units using
     # ConditionNeedsUpdate=
     # See: https://github.com/systemd/systemd/issues/15724#issuecomment-628194867
-    "systemd.clock_usec=$(($(date +%s%N) / 1000 + 1))"
+    #"systemd.clock_usec=$(($(date +%s%N) / 1000 + 1))"
+    # Update: if the original time difference is too big, the mtime of
+    # /etc/.updated is already too far in the future, so it doesn't matter if
+    # we correct the time during the next boot, since it's still going to be
+    # in the past. Let's just explicitly override all ConditionNeedsUpdate=
+    # directives to true to fix this once and for all
+    "systemd.condition-needs-update=1"
 )
 grubby --args="${GRUBBY_ARGS[*]}" --update-kernel="$(grubby --default-kernel)"
 # Check if the $GRUBBY_ARGS were applied correctly


### PR DESCRIPTION
This is a followup to c887e91ec60cbf686a74583ab73f98acccce595a.

Unfortunately, if the original time difference is too big, the mtime of
/etc/.updated is already too far in the future, so it doesn't matter if
we correct the time during the next boot, since it's still going to be
in the past. Let's just explicitly override all ConditionNeedsUpdate=
directives to true to fix this once and for all.

Example from the recent fail:
Current date:         Wed 27 May 11:07:42 BST 2020
RTC:                  2020-05-27 11:07:41.871700+01:00
/usr mtime:           Wed 27 May 11:03:58 BST 2020
/etc/.updated mtime:  Wed 27 May 11:46:28 BST 2020

the /etc/.updated mtime is in the future after the time correction, so
the units with ConditionNeedsUpdate= will be skipped on the next boot in
any case, causing unexpected test fails.