### PR TITLE
vagrant: add additional debug checks to track down the NFS issue

### DIFF
--- a/vagrant/vagrant-build.sh
+++ b/vagrant/vagrant-build.sh
@@ -82,7 +82,7 @@ pushd "$TEST_DIR" || { echo >&2 "Can't pushd to $TEST_DIR"; exit 1; }
 cp $VAGRANT_ROOT/vagrant-test*.sh "$TEST_DIR/"
 
 # Provision the machine
-vagrant up --no-tty --provider=libvirt
+VAGRANT_LOG=info vagrant up --no-tty --provider=libvirt
 
 set +e
 

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -84,3 +84,8 @@ systemctl enable  nfs-server
 systemctl restart nfs-server
 systemctl status nfs-server
 sleep 10
+
+# Debug
+grep nfsd /proc/filesystems
+exportfs -sv
+modinfo nfs nfsd


### PR DESCRIPTION
As 541d0b008bac788e75d9bdd37437294bcbb3ab2e didn't help (sigh), let's
add a few more useful debug checks and raise the log level of vagrant
during provisioning.