### PR TITLE
Revert "vagrant: halve the number of concurrent tasks"

### DIFF
--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -54,13 +54,6 @@ if ! initialize_integration_tests "$PWD"; then
     exit 1
 fi
 
-# Time has shown that the kernel has apparently a hard time with 4 parallel VMs
-# inside of another VM, causing frequent soft/hard vCPU lockups.
-# Let's halve the amount of parallel tasks in an attempt to avoid this.
-# (This overrides variables defined in task-control.sh)
-export OPTIMAL_QEMU_SMP=4
-export MAX_QUEUE_SIZE=2
-
 # Parallelized tasks
 SKIP_LIST=(
     "test/TEST-10-ISSUE-2467"       # Serialized below


### PR DESCRIPTION
This reverts commit 8779abe.

After some debugging I noticed that the issue is still present, even
when the number of concurrent jobs is halved. However, when trying to
get deeper, the issue completely disappeared and I failed to reproduce
it in more than 20 consecutive runs.

In lights of this let's drop the workaround, since it doesn't work, and
wait if the issue reappears to dig into it even further.