### PR TITLE
agent/vagrant: add new test dependencies for systemd/systemd#16046

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -46,7 +46,8 @@ yum -y install epel-release yum-utils gdb
 yum-config-manager --enable epel
 yum -y update
 yum -y install busybox dnsmasq e2fsprogs gcc-c++ libasan libbpf-devel libfdisk-devel meson nc net-tools ninja-build \
-                  openssl-devel pcre2-devel python36 python-lxml qemu-kvm quota socat strace systemd-ci-environment
+                  openssl-devel pcre2-devel python36 python-lxml qemu-kvm quota socat squashfs-tools strace \
+                  systemd-ci-environment veritysetup
 
 # python36 package doesn't create the python3 symlink
 rm -f /usr/bin/python3

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -64,7 +64,7 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S coreutils busybox dhclient dhcpcd diffutils dnsmasq e2fsprogs \
-        gdb inetutils net-tools openbsd-netcat qemu rsync socat strace vi
+        gdb inetutils net-tools openbsd-netcat qemu rsync socat squashfs-tools strace vi
 
     # Configure NTP (chronyd)
     pacman --needed --noconfirm -S chrony


### PR DESCRIPTION
Namely:
    * squashfs-tools for mksquashfs (Arch/CentOS 7)
    * veritysetup for veritysetup (CentOS 7, on Arch the binary is part
      of the cryptsetup package)