### PR TITLE
vagrant: avoid using HT cores on "dusty" CentOS CI machines

### DIFF
--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -35,6 +35,9 @@ else
     OPTIMAL_QEMU_SMP=${OPTIMAL_QEMU_SMP:-1}
 fi
 
+echo "[TASK-CONTROL] OPTIMAL_QEMU_SMP = $OPTIMAL_QEMU_SMP"
+echo "[TASK-CONTROL] MAX_QUEUE_SIZE = $MAX_QUEUE_SIZE"
+
 # Active wait for PID to finish
 #   - print '.' every 10 seconds
 #   - return the exit code of the waited for process

--- a/vagrant/vagrant-build.sh
+++ b/vagrant/vagrant-build.sh
@@ -64,7 +64,15 @@ fi
 export SYSTEMD_ROOT="${SYSTEMD_ROOT:-$HOME/systemd}"
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
 export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
-export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
+if [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]]; then
+    # All dusty machines have Intel Xeon CPUs with 4 cores and HT enabled,
+    # which causes issues when the HT cores are counted as "real" ones, namely
+    # CPU over-saturation and strange hangups. As all dusty server have the
+    # same HW, let's manually override the # of CPUs for the VM to 4.
+    export VAGRANT_CPUS=4
+else
+    export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
+fi
 export VAGRANT_BOOTSTRAP_SCRIPT="$BOOTSTRAP_SCRIPT"
 
 # Absolute systemd git root path on the host machine


### PR DESCRIPTION
Treating HT cores as "real" cores causes CPU over-saturation related
issues and random test fails. Since this happens only on "dusty" machines
(*.dusty.ci.centos.org), let's explicitly exclude HT cores there from the
total number of cores when creating a VM.

Hopefully addresses #270.
