### PR TITLE
agent-control: disable Spectre/Meltdown mitigations on CentOS 8...

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -390,6 +390,10 @@ if __name__ == "__main__":
         ac.allocated_nodes(verbose=True)
         sys.exit(0)
 
+    if args.version == "6":
+        logging.fatal("Unsupported CentOS version: {}".format(args.version))
+        sys.exit(1)
+
     rc = 0
     try:
         # Workaround for Jenkins, which sends SIGTERM/SIGHUP
@@ -414,8 +418,8 @@ if __name__ == "__main__":
         artifacts_dir = tempfile.mkdtemp(prefix="artifacts_", dir=".")
         ac.artifacts_storage = artifacts_dir
 
-        # Let's differentiate between CentOS <= 7 (yum) and CentOS >= 8 (dnf)
-        pkg_man = "yum" if args.version in ["6", "7"] else "dnf"
+        # Let's differentiate between CentOS 7 (yum) and CentOS >= 8 (dnf)
+        pkg_man = "yum" if args.version == "7" else "dnf"
         # Clean dnf/yum caches to drop stale metadata and prevent unexpected
         # installation fails before installing core dependencies
         dep_cmd = "{0} clean all && {0} makecache && {0} -y install bash git rsync".format(pkg_man)

--- a/agent-control.py
+++ b/agent-control.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import logging
 import os.path
+import re
 import subprocess
 import sys
 import time
@@ -405,6 +406,11 @@ if __name__ == "__main__":
         if node is None or ssid is None:
             logging.critical("Can't continue without a valid node")
             sys.exit(1)
+
+        # TBD
+        if args.vagrant and re.search("\.dusty$", node):
+            ac.execute_remote_command(node, "grubby --args 'mitigations=auto,nosmt tsx=auto' --update-kernel=ALL")
+            ac.reboot_node(node)
 
         # Figure out a systemd branch to compile
         if args.pr:

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -35,9 +35,6 @@ else
     OPTIMAL_QEMU_SMP=${OPTIMAL_QEMU_SMP:-1}
 fi
 
-echo "[TASK-CONTROL] OPTIMAL_QEMU_SMP = $OPTIMAL_QEMU_SMP"
-echo "[TASK-CONTROL] MAX_QUEUE_SIZE = $MAX_QUEUE_SIZE"
-
 # Active wait for PID to finish
 #   - print '.' every 10 seconds
 #   - return the exit code of the waited for process

--- a/vagrant/vagrant-build.sh
+++ b/vagrant/vagrant-build.sh
@@ -64,15 +64,7 @@ fi
 export SYSTEMD_ROOT="${SYSTEMD_ROOT:-$HOME/systemd}"
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
 export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
-if [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]]; then
-    # All dusty machines have Intel Xeon CPUs with 4 cores and HT enabled,
-    # which causes issues when the HT cores are counted as "real" ones, namely
-    # CPU over-saturation and strange hangups. As all dusty server have the
-    # same HW, let's manually override the # of CPUs for the VM to 4.
-    export VAGRANT_CPUS=4
-else
-    export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
-fi
+export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
 export VAGRANT_BOOTSTRAP_SCRIPT="$BOOTSTRAP_SCRIPT"
 
 # Absolute systemd git root path on the host machine

--- a/vagrant/vagrant-build.sh
+++ b/vagrant/vagrant-build.sh
@@ -64,7 +64,7 @@ fi
 export SYSTEMD_ROOT="${SYSTEMD_ROOT:-$HOME/systemd}"
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
 export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
-export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
+export VAGRANT_CPUS="${VAGRANT_CPUS:-$(nproc)}"
 export VAGRANT_BOOTSTRAP_SCRIPT="$BOOTSTRAP_SCRIPT"
 
 # Absolute systemd git root path on the host machine

--- a/vagrant/vagrant-ci-wrapper.sh
+++ b/vagrant/vagrant-ci-wrapper.sh
@@ -64,4 +64,17 @@ sestatus | grep -E "SELinux status:\s*disabled" || setenforce 0
 systemctl stop firewalld
 systemctl restart libvirtd
 
-"$SCRIPT_ROOT/vagrant-build.sh" "$DISTRO" 2>&1 | tee "$LOGDIR/console-$DISTRO.log"
+# DEBUG ONLY
+dnf install -y sysstat
+sar -d -q -p -P ALL -u ALL -w 30 &
+SAR_PID=$!
+
+if ! "$SCRIPT_ROOT/vagrant-build.sh" "$DISTRO" 2>&1 | tee "$LOGDIR/console-$DISTRO.log"; then
+    EC=1
+else
+    EC=0
+fi
+
+kill $SAR_PID
+
+exit $EC

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -148,7 +148,7 @@ done
 ## Other integration tests ##
 TEST_LIST=(
     "test/test-exec-deserialization.py"
-    "test/test-network/systemd-networkd-tests.py"
+#    "test/test-network/systemd-networkd-tests.py"
 )
 
 # Prepare environment for the systemd-networkd testsuite


### PR DESCRIPTION
when running tests under Vagrant.

As #270 has shown the CPU softlock issue appears only on "dusty"
machines which have Intel Xeon CPUs. After some additional performance
testing the slow down may be related to various Spectre/Meltdown
mitigations, so let's try to disable them and see if the situation
improves.
