### PR TITLE
vagrant: test the updated image before using it in production

### DIFF
--- a/jenkins/runners/systemd-centos-ci-vagrant-make-cache.sh
+++ b/jenkins/runners/systemd-centos-ci-vagrant-make-cache.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Note: this script MUST be self-contained - i.e. it MUST NOT source any
+# external scripts as it is used as a bootstrap script, thus it's
+# fetched and executed without rest of this repository
+#
+# Example usage in Jenkins
+# #!/bin/sh
+#
+# set -e
+#
+# curl -q -o runner.sh https://../systemd-centos-ci-vagrant-make-cache.sh
+# chmod +x runner.sh
+# ./runner.sh
+
+set -e
+set -o pipefail
+
+at_exit() {
+    # Correctly collect artifacts from all cron jobs and generate a nice
+    # directory structure
+    if find . -name "artifacts_*" | grep -q "."; then
+        mkdir _artifacts_all
+        mv artifacts_* _artifacts_all
+        mv _artifacts_all artifacts_all
+
+        utils/generate-index.sh artifacts_all index.html
+    fi
+}
+
+trap at_exit EXIT
+
+export PATH="/home/systemd/bin:$PATH"
+ARGS="${ARGS:-""}"
+
+git clone https://github.com/systemd/systemd-centos-ci
+cd systemd-centos-ci
+
+# Generate a new image with '-new' suffix
+./agent-control.py --version 8 --vagrant-sync $ARGS
+# Check if it doesn't break anything
+./agent-control.py --version 8 --no-index --vagrant arch-new $ARGS
+./agent-control.py --version 8 --no-index --vagrant arch-sanitizers-clang-new $ARGS
+# Overwrite the production image with the just tested one. Since the CentOS CI
+# artifact server supports only rsync protocol, use a single-purpose script
+# to do that
+utils/artifacts-copy-file.sh vagrant_boxes/archlinux_systemd-new vagrant_boxes/archlinux_systemd

--- a/utils/artifacts-copy-file.sh
+++ b/utils/artifacts-copy-file.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Single purpose script to copy a file from one place to another using rsync,
+# since the CentOS CI artifact server supports only rsync.
+# Disclaimer: this doesn't work in all cases - it was written to "simply" rename
+#             a file using the rsync protocol, so please bear that in mind.
+set -eu
+set -o pipefail
+
+# CentOS CI specific thing - a part of the duffy key is necessary to
+# authenticate against the CentOS CI rsync server
+# See: https://wiki.centos.org/QaWiki/CI/GettingStarted#Exporting_artifacts_.28if_needed.29_to_a_storage_box
+DUFFY_KEY_FILE="$HOME/duffy.key"
+PASSWORD_FILE="$(mktemp "$PWD/.rsync-passwd.XXX")"
+SRC="${1:?Missing argument: source}"
+DEST="${2:?Missing argument: destination}"
+[[ "$SRC" == */* ]] && SRC_DIR="${SRC%/*}" || SRC_DIR="."
+[[ "$DEST" == */* ]] && DEST_DIR="${DEST%/*}" || DEST_DIR="."
+TEMP_DIR="$(mktemp -d "$PWD/.sync-dirXXX")"
+
+trap "cd && rm -fr '$TEMP_DIR' '$PASSWORD_FILE'" EXIT
+
+cut -b-13 "$DUFFY_KEY_FILE" > "$PASSWORD_FILE"
+
+pushd "$TEMP_DIR"
+mkdir -p "$SRC_DIR" "$DEST_DIR"
+# Crucial line, otherwise we won't be able to access the web directory listing
+chmod -R o+rx .
+
+rsync --password-file="$PASSWORD_FILE" -av "systemd@artifacts.ci.centos.org::systemd/$SRC" "$SRC_DIR"
+mv -v "$SRC" "$DEST"
+rm -fr "$SRC"
+rsync --password-file="$PASSWORD_FILE" -av . "systemd@artifacts.ci.centos.org::systemd/"
+
+popd

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -42,6 +42,15 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -e
 
+    # The latest generic/arch image switched from 'scsi' disk bus driver to 'virtio'
+    # but /etc/fstab still contains '/dev/sda*' entries instead of '/dev/vda*'
+    # causing slow downs and unexpected system fails. Let's workaround it until
+    # it's fixed.
+    # See: https://github.com/lavabit/robox/issues/152
+    grep /dev/sda /etc/fstab && sed -i "s#/dev/sda#/dev/vda#g" /etc/fstab && systemctl daemon-reload
+    cat /etc/fstab
+    lsblk
+
     whoami
 
     # Initialize pacman's keyring

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -29,10 +29,6 @@ Vagrant.configure("2") do |config|
     libvirt.memory = if ENV["VAGRANT_MEMORY"] then ENV["VAGRANT_MEMORY"] else  "8192" end
     libvirt.cpus = if ENV["VAGRANT_CPUS"] then ENV["VAGRANT_CPUS"] else 8 end
 
-    if ENV["VAGRANT_DISK_BUS"] then
-      libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
-    end
-
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
   end

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Relatively simple script which updates Vagrant boxes used by systemd CentOS CI
+# Script which updates Vagrant boxes used by systemd CentOS CI
 # with build dependencies and other configuration, so we don't have to that in
 # every CI job. These updated images are then stored on the CentOS CI artifact
 # server and can be reused by other CI jobs.
@@ -19,10 +19,10 @@ EC=0
 # authenticate against the CentOS CI rsync server
 DUFFY_KEY_FILE="/duffy.key"
 VAGRANT_ROOT="$(dirname $(readlink -f $0))"
-# Relative paths to cache-able Vagrantfiles
-VAGRANTFILES=(
-    $VAGRANT_ROOT/boxes/Vagrantfile_archlinux_systemd
-)
+VAGRANTFILE="$VAGRANT_ROOT/boxes/Vagrantfile_archlinux_systemd"
+
+# Disable SELinux on the test hosts and avoid false positives.
+sestatus | grep -E "SELinux status:\s*disabled" || setenforce 0
 
 # Install vagrant if not already installed
 $VAGRANT_ROOT/vagrant-setup.sh
@@ -31,84 +31,82 @@ $VAGRANT_ROOT/vagrant-setup.sh
 systemctl stop firewalld
 systemctl restart libvirtd
 
-for vagrantfile in "${VAGRANTFILES[@]}"; do
-    TEMP_DIR="$(mktemp -d vagrant-cache-XXXXX)"
-    pushd "$TEMP_DIR" || { echo >&2 "Can't pushd to $TEMP_DIR"; exit 1; }
+TEMP_DIR="$(mktemp -d vagrant-cache-XXXXX)"
+pushd "$TEMP_DIR" || { echo >&2 "Can't pushd to $TEMP_DIR"; exit 1; }
 
-    # Start a VM described in the Vagrantfile with all provision steps
-    export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
-    export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
-    export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
-    export VAGRANT_DISK_BUS
+# Start a VM described in the Vagrantfile with all provision steps
+export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
+export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
+export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
+export VAGRANT_DISK_BUS
 
-    cp "$vagrantfile" Vagrantfile
+cp "$VAGRANTFILE" Vagrantfile
+vagrant up --no-tty --provider=libvirt
+# Register a cleanup handler
+trap "cd $PWD && vagrant destroy -f && cd / && rm -fr $TEMP_DIR" EXIT
+
+timeout 5m vagrant reload
+case $? in
+    0)
+        ;;
+    124)
+        echo >&2 "Timeout during machine reboot"
+        exit 124
+        ;;
+    *)
+        echo >&2 "Failed to reboot the VM using 'vagrant reload'"
+        exit 1
+        ;;
+esac
+vagrant halt
+
+# Create a box from the VM, so it can be reused later
+# Output file example:
+#   boxes/Vagrantfile_archlinux_systemd => archlinux_systemd
+BOX_NAME="${VAGRANTFILE##*/Vagrantfile_}"
+# Workaround for `virt-sysprep` - work with the image via qemu directly
+# instead of using libvirt
+export LIBGUESTFS_BACKEND=direct
+# You guessed it, another workaround - let's include the original
+# Vagrantfile as well, as it usually contains important settings
+# which make the box actually bootable. For this, we need to detect the location
+# of the box, from the original box name (i.e. generic/arch, see the
+# beautiful awk below), and then transform it to a path to the Vagrantfile,
+# which contains the box name, but all slashes are replaced by
+# "-VAGRANTSLASH-" (and that's what the bash substitution is for)
+ORIGINAL_BOX_NAME="$(awk 'match($0, /^[^#]*config.vm.box\s*=\s*"([^"]+)"/, m) { print m[1]; exit 0; }' "$VAGRANTFILE")"
+vagrant package --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/${ORIGINAL_BOX_NAME//\//-VAGRANTSLASH-}/*/libvirt/Vagrantfile
+
+# Check if we can build a usable VM from the just packaged box
+(
+    TEST_DIR="$(mktemp -d testbox.XXX)"
+    INNER_EC=0
+
+    vagrant box remove -f testbox || :
+    vagrant box add --name testbox "$BOX_NAME"
+    pushd "$TEST_DIR"
+    vagrant init testbox
     vagrant up --no-tty --provider=libvirt
-    # Register a cleanup handler
-    trap "cd $PWD && vagrant destroy -f && cd / && rm -fr $TEMP_DIR" EXIT
+    vagrant ssh -c "uname -a" || INNER_EC=1
 
-    timeout 5m vagrant reload
-    case $? in
-        0)
-            ;;
-        124)
-            echo >&2 "Timeout during machine reboot"
-            exit 124
-            ;;
-        *)
-            echo >&2 "Failed to reboot the VM using 'vagrant reload'"
-            exit 1
-            ;;
-    esac
-    vagrant halt
+    # Cleanup
+    vagrant destroy -f
+    vagrant box remove -f testbox
+    popd && rm -fr "$TEST_DIR"
 
-    # Create a box from the VM, so it can be reused later
-    # Output file example:
-    #   boxes/Vagrantfile_archlinux_systemd => archlinux_systemd
-    BOX_NAME="${vagrantfile##*/Vagrantfile_}"
-    # Workaround for `virt-sysprep` - work with the image via qemu directly
-    # instead of using libvirt
-    export LIBGUESTFS_BACKEND=direct
-    # You guessed it, another workaround - let's include the original
-    # Vagrantfile as well, as it usually contains important settings
-    # which make the box actually bootable. For this, we need to detect the location
-    # of the box, from the original box name (i.e. generic/arch, see the
-    # beautiful awk below), and then transform it to a path to the Vagrantfile,
-    # which contains the box name, but all slashes are replaced by
-    # "-VAGRANTSLASH-" (and that's what the bash substitution is for)
-    ORIGINAL_BOX_NAME="$(awk 'match($0, /^[^#]*config.vm.box\s*=\s*"([^"]+)"/, m) { print m[1]; exit 0; }' "$vagrantfile")"
-    vagrant package --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/${ORIGINAL_BOX_NAME//\//-VAGRANTSLASH-}/*/libvirt/Vagrantfile
+    exit $INNER_EC
+)
 
-    # Check if we can build a usable VM from the just packaged box
-    (
-        TEST_DIR="$(mktemp -d testbox.XXX)"
-        EC=0
+# Upload the box to the CentOS CI artifact storage
+# CentOS CI rsync password is the first 13 characters of the duffy key
+PASSWORD_FILE="$(mktemp .rsync-passwd.XXX)"
+cut -b-13 "$DUFFY_KEY_FILE" > "$PASSWORD_FILE"
 
-        vagrant box remove -f testbox || :
-        vagrant box add --name testbox "$BOX_NAME"
-        pushd "$TEST_DIR"
-        vagrant init testbox
-        vagrant up --no-tty --provider=libvirt
-        vagrant ssh -c "uname -a" || EC=1
+# Little workaround to create a proper directory hierarchy on the server
+mkdir vagrant_boxes
+mv "$BOX_NAME" vagrant_boxes
 
-        # Cleanup
-        vagrant destroy -f
-        vagrant box remove -f testbox
-        popd && rm -fr "$TEST_DIR"
-
-        exit $EC
-    )
-
-    # Upload the box to the CentOS CI artifact storage
-    # CentOS CI rsync password is the first 13 characters of the duffy key
-    PASSWORD_FILE="$(mktemp .rsync-passwd.XXX)"
-    cut -b-13 "$DUFFY_KEY_FILE" > "$PASSWORD_FILE"
-
-    # Little workaround to create a proper directory hierarchy on the server
-    mkdir vagrant_boxes
-    mv "$BOX_NAME" vagrant_boxes
-
-    rsync --password-file="$PASSWORD_FILE" -av "vagrant_boxes" systemd@artifacts.ci.centos.org::systemd/
-    echo "Box URL: http://artifacts.ci.centos.org/systemd/vagrant_boxes/$BOX_NAME"
-done
+rsync --password-file="$PASSWORD_FILE" -av "vagrant_boxes" systemd@artifacts.ci.centos.org::systemd/
+echo "Box URL: http://artifacts.ci.centos.org/systemd/vagrant_boxes/$BOX_NAME"
 
 exit $EC

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -38,7 +38,6 @@ pushd "$TEMP_DIR" || { echo >&2 "Can't pushd to $TEMP_DIR"; exit 1; }
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
 export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
 export VAGRANT_CPUS="${VAGRANT_CPUS:-$(nproc)}"
-export VAGRANT_DISK_BUS
 
 cp "$VAGRANTFILE" Vagrantfile
 vagrant up --no-tty --provider=libvirt

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -37,7 +37,7 @@ pushd "$TEMP_DIR" || { echo >&2 "Can't pushd to $TEMP_DIR"; exit 1; }
 # Start a VM described in the Vagrantfile with all provision steps
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
 export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
-export VAGRANT_CPUS="${VAGRANT_CPUS:-8}"
+export VAGRANT_CPUS="${VAGRANT_CPUS:-$(nproc)}"
 export VAGRANT_DISK_BUS
 
 cp "$VAGRANTFILE" Vagrantfile
@@ -60,10 +60,11 @@ case $? in
 esac
 vagrant halt
 
-# Create a box from the VM, so it can be reused later
+# Create a box from the VM, so it can be reused later. The box name is suffixed
+# with '-new' to avoid using it immediately in "production".
 # Output file example:
-#   boxes/Vagrantfile_archlinux_systemd => archlinux_systemd
-BOX_NAME="${VAGRANTFILE##*/Vagrantfile_}"
+#   boxes/Vagrantfile_archlinux_systemd => archlinux_systemd-new
+BOX_NAME="${VAGRANTFILE##*/Vagrantfile_}-new"
 # Workaround for `virt-sysprep` - work with the image via qemu directly
 # instead of using libvirt
 export LIBGUESTFS_BACKEND=direct

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -75,7 +75,7 @@ export LIBGUESTFS_BACKEND=direct
 # which contains the box name, but all slashes are replaced by
 # "-VAGRANTSLASH-" (and that's what the bash substitution is for)
 ORIGINAL_BOX_NAME="$(awk 'match($0, /^[^#]*config.vm.box\s*=\s*"([^"]+)"/, m) { print m[1]; exit 0; }' "$VAGRANTFILE")"
-vagrant package --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/${ORIGINAL_BOX_NAME//\//-VAGRANTSLASH-}/*/libvirt/Vagrantfile
+vagrant package --no-tty --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/${ORIGINAL_BOX_NAME//\//-VAGRANTSLASH-}/*/libvirt/Vagrantfile
 
 # Check if we can build a usable VM from the just packaged box
 (

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -147,7 +147,7 @@ done
 
 ## Other integration tests ##
 TEST_LIST=(
-#    "test/test-exec-deserialization.py"
+    "test/test-exec-deserialization.py"
     "test/test-network/systemd-networkd-tests.py"
 )
 

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -16,8 +16,13 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
-  config.vm.box = "archlinux_systemd"
-  config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
+  if ENV["VAGRANT_TEST_IMAGE"] then
+    config.vm.box = "archlinux_systemd-new"
+    config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd-new"
+  else
+    config.vm.box = "archlinux_systemd"
+    config.vm.box_url = "http://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
+  end
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -73,10 +73,6 @@ Vagrant.configure("2") do |config|
     libvirt.memory = if ENV["VAGRANT_MEMORY"] then ENV["VAGRANT_MEMORY"] else  "8192" end
     libvirt.cpus = if ENV["VAGRANT_CPUS"] then ENV["VAGRANT_CPUS"] else 8 end
 
-    if ENV["VAGRANT_DISK_BUS"] then
-      libvirt.disk_bus = ENV["VAGRANT_DISK_BUS"]
-    end
-
     # Collect output from a serial console into a file to make debugging easier
     # The -nographic option allows us to collect BIOS messages as well
     libvirt.qemuargs :value => "-nographic"


### PR DESCRIPTION
So far we updated the Vagrant image every couple of days, gave it a
quick boot test to see if it's bootable, and then pushed it directly
into production. However, time has shown that this is actually not the
smartest idea, because there can be some interface changes or even bugs
introduced in some of the updated images, which completely breaks CI for
a while.

To avoid such scenarios, let's suffix the updated image with '-new', run
it through our usual pipelines, and if it succeeds drop the
'-new' suffix so the standard pipeline can use it without worrying it
may not work.

TBD: the renaming part, documentation
