### PR TITLE
agent/vagrant: don't remove the pre-initialized $TESTDIR

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -107,8 +107,10 @@ for t in test/TEST-??-*; do
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
-    rm -fr "$TESTDIR"
+    # Skipped test don't create the $TESTDIR automatically, so do it explicitly
+    # otherwise the `touch` command would fail
     mkdir -p "$TESTDIR"
+    rm -f "$TESTDIR/pass"
 
     exectask_p "${t##*/}" "make -C $t setup run && touch $TESTDIR/pass"
 done

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -84,8 +84,10 @@ for t in test/TEST-??-*; do
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
-    rm -fr "$TESTDIR"
+    # Skipped test don't create the $TESTDIR automatically, so do it explicitly
+    # otherwise the `touch` command would fail
     mkdir -p "$TESTDIR"
+    rm -f "$TESTDIR/pass"
 
     exectask_p "${t##*/}" "make -C $t setup run && touch $TESTDIR/pass"
 done
@@ -115,8 +117,10 @@ for t in "${SERIALIZED_TASKS[@]}"; do
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
-    rm -fr "$TESTDIR"
+    # Skipped test don't create the $TESTDIR automatically, so do it explicitly
+    # otherwise the `touch` command would fail
     mkdir -p "$TESTDIR"
+    rm -f "$TESTDIR/pass"
 
     exectask "${t##*/}" "make -C $t setup run && touch $TESTDIR/pass"
 done


### PR DESCRIPTION
After the test suite rewrite we do a test pre-initialization via
initialize_integration_tests() helper, so we shouldn't clean up the just
initialized $TESTDIR anymore.