### PR TITLE
common: halve the parallelization workload

### DIFF
--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -21,7 +21,7 @@ declare -A TASK_QUEUE=()
 # utility. If that fails, fall back to using default values for necessary
 # variables.
 if NPROC=$(nproc); then
-    OPTIMAL_QEMU_SMP=2
+    OPTIMAL_QEMU_SMP=4
     MAX_QUEUE_SIZE=$((NPROC / OPTIMAL_QEMU_SMP))
     if [[ $MAX_QUEUE_SIZE -lt 1 ]]; then
         # We have enough CPUs for only one concurrent task


### PR DESCRIPTION
I noticed a rising amount of flakes since the introduction of
parallelization, many of them showing signs of CPU or I/O
starvation/overload. Let's halve the overall parallelization workload in
an attempt to trade off some overall speed for stability.
