### PR TITLE
agent: reuse the corrected time & date after reboot

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -188,13 +188,16 @@ GRUBBY_ARGS=(
     # it early in the boot process to properly execute units using
     # ConditionNeedsUpdate=
     # See: https://github.com/systemd/systemd/issues/15724#issuecomment-628194867
-    #"systemd.clock_usec=$(($(date +%s%N) / 1000 + 1))"
     # Update: if the original time difference is too big, the mtime of
     # /etc/.updated is already too far in the future, so it doesn't matter if
     # we correct the time during the next boot, since it's still going to be
     # in the past. Let's just explicitly override all ConditionNeedsUpdate=
     # directives to true to fix this once and for all
     "systemd.condition-needs-update=1"
+    # Also, store & reuse the current (and corrected) time & date, as it doesn't
+    # persist across reboots without this kludge and can (actually it does)
+    # interfere with running tests
+    "systemd.clock_usec=$(($(date +%s%N) / 1000 + 1))"
 )
 grubby --args="${GRUBBY_ARGS[*]}" --update-kernel="$(grubby --default-kernel)"
 # Check if the $GRUBBY_ARGS were applied correctly


### PR DESCRIPTION
The corrected time & date doesn't persist across reboots, which means
that the machine will use the borked RTC time on the next boot. In that
case chrony attempts to fix it, but sometimes it does it too late in the
test phase. When this happens after some of the test images were
generated, they contain files with timestamps from the future, which
confuses the systemd unit cache after the time gets corrected, leading
to many unexpected (and bogus) fails because of missing unit files.

Related: https://github.com/systemd/systemd-centos-ci/issues/251#issuecomment-648180867