### PR TITLE
vagrant: temporarily disable test_macsec

### DIFF
--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -45,6 +45,14 @@ fi
 # test-journal-flush: unstable on nested KVM
 echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
 
+## FIXME: systemd-networkd testsuite: skip test_macsec
+# Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
+# dereference (and since 5.8.0 an additional oops). Since the issue hasn't been
+# looked at/fixed for over a month now, let's disable the failing test to
+# no longer block the CI image updates.
+# See: systemd/systemd#16199
+sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
+
 ## Temporary wrapper for `meson test` which disables LSan for `test-execute`
 # LSan keeps randomly crashing during `test-execute` so let's (temporarily)
 # disable it until we find out the culprit.

--- a/vagrant/vagrant-test.sh
+++ b/vagrant/vagrant-test.sh
@@ -32,6 +32,14 @@ echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 
+## FIXME: systemd-networkd testsuite: skip test_macsec
+# Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
+# dereference (and since 5.8.0 an additional oops). Since the issue hasn't been
+# looked at/fixed for over a month now, let's disable the failing test to
+# no longer block the CI image updates.
+# See: systemd/systemd#16199
+sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
+
 ## Integration test suite ##
 # Prepare a custom-tailored initrd image (with the systemd module included).
 # This is necessary, as the default mkinitcpio config includes only the udev module,


### PR DESCRIPTION
Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
dereference (and since 5.8.0 an additional oops). Since the issue hasn't been
looked at/fixed for over a month now, let's disable the failing test to
no longer block the CI image updates.
See: systemd/systemd#16199