### PR TITLE
Revert "vagrant: temporarily disable test_macsec"

### DIFF
--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -31,6 +31,8 @@ swapoff -av
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
+sed -i '/@unittest.skip/d' test/test-network/systemd-networkd-tests.py
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 [[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"


### PR DESCRIPTION
This reverts commit 317ae72bc0262e09080e1e0eeaf77a0013a685b2.

---

This should serve as a *simple* check for https://github.com/systemd/systemd/issues/16199 to see if the issue has been finally resolved. I'll try to re-trigger it after each image update (that's twice a week), so we can have the test back as soon as possible.