### PR TITLE
Support alternative architectures (ppc64le & aarch64)

### DIFF
--- a/agent/bootstrap-alt.sh
+++ b/agent/bootstrap-alt.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/bash
+
+LIB_ROOT="$(dirname "$0")/../common"
+# shellcheck source=common/task-control.sh
+. "$LIB_ROOT/task-control.sh" "bootstrap-logs-upstream-$(uname -m)" || exit 1
+# shellcheck source=common/utils.sh
+. "$LIB_ROOT/utils.sh" || exit 1
+
+BUILD_DIR="${BUILD_DIR:-/systemd-meson-build}"
+REPO_URL="${REPO_URL:-https://github.com/systemd/systemd.git}"
+REMOTE_REF=""
+
+# EXIT signal handler
+at_exit() {
+    # Let's collect some build-related logs
+    set +e
+    rsync -amq /var/tmp/systemd-test*/system.journal "$LOGDIR/sanity-boot-check.journal" &>/dev/null || :
+    exectask "journalctl-bootstrap" "journalctl -b --no-pager"
+    exectask "list-of-installed-packages" "rpm -qa"
+}
+
+trap at_exit EXIT
+
+# Parse optional script arguments
+while getopts "r:" opt; do
+    case "$opt" in
+        r)
+            REMOTE_REF="$OPTARG"
+            ;;
+        ?)
+            exit 1
+            ;;
+        *)
+            echo "Usage: $0 [-r REMOTE_REF]"
+            exit 1
+    esac
+done
+
+# All commands from this script are fundamental, ensure they all pass
+# before continuing (or die trying)
+set -eu
+set -o pipefail
+
+ADDITIONAL_DEPS=(
+    attr
+    busybox
+    clang
+    compiler-rt
+    dhcp-client
+    dhcp-server
+    dnsmasq
+    dosfstools
+    e2fsprogs
+    gdb
+    iproute-tc
+    kernel-modules-extra
+    kmod-wireguard # Kmods SIG
+    libasan
+    libfdisk-devel
+    libidn2-devel
+    libpwquality-devel
+    libubsan
+    libzstd-devel
+    llvm
+    make
+    net-tools
+    nmap-ncat
+    openssl-devel
+    perl-IPC-SysV
+    perl-Time-HiRes
+    python3-jinja2
+    qemu-kvm
+    qrencode-devel
+    quota
+    socat
+    squashfs-tools
+    strace
+    systemd-networkd # EPEL
+    time
+    veritysetup
+    wget
+)
+
+dnf -y install epel-release epel-next-release dnf-plugins-core gdb
+dnf -y config-manager --enable epel --enable powertools
+# Install the Kmods SIG repository for certain kernel modules
+# See: https://sigs.centos.org/kmods/repositories/
+cmd_retry dnf -y install centos-release-kmods
+# Local mirror of https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci-centos8/
+dnf -y config-manager --add-repo "http://artifacts.ci.centos.org/systemd/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
+dnf -y update
+# Install systemd's build dependencies
+# Note: --skip-unavailable is necessary as the systemd SRPM has a gnu-efi
+#       dependency, but the package is not available on ppc64le, causing
+#       the builddep command to fail. The dependency is conditional, but
+#       the condition is not resolved during the build dep installation
+dnf -y --skip-unavailable builddep systemd
+dnf -y install "${ADDITIONAL_DEPS[@]}"
+# Remove setroubleshoot-server if it's installed, since we don't use it anyway
+# and it's causing some weird performance issues
+if rpm -q setroubleshoot-server; then
+    dnf -y remove setroubleshoot-server
+fi
+# Use the Nmap's version of nc, since TEST-13-NSPAWN-SMOKE doesn't seem to work
+# with the OpenBSD version present on CentOS 8
+if alternatives --display nmap; then
+    alternatives --set nmap /usr/bin/ncat
+    alternatives --display nmap
+fi
+
+# Fetch the upstream systemd repo
+test -e systemd && rm -rf systemd
+git clone "$REPO_URL" systemd
+pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
+
+git_checkout_pr "$REMOTE_REF"
+
+# It's impossible to keep the local SELinux policy database up-to-date with
+# arbitrary pull request branches we're testing against.
+# Disable SELinux on the test hosts and avoid false positives.
+if setenforce 0; then
+    echo SELINUX=disabled >/etc/selinux/config
+fi
+
+# Disable firewalld (needed for systemd-networkd tests)
+systemctl disable firewalld
+
+# Unlike gcc's ASan, clang's ASan DSO is in a non-standard path, thus any binary
+# compiled with -shared-libasan using clang will fail to start. Let's add the
+# necessary path to the ldconfig cache to avoid that.
+ARCH="$(uname -m)"
+[[ $ARCH == ppc64le ]] && ARCH=powerpc64le
+if ! ASAN_RT_PATH="$(${CC:-clang} --print-file-name "libclang_rt.asan-$ARCH.so")" || ! [[ -f "$ASAN_RT_PATH" ]]; then
+    echo >&2 "Couldn't detect path to the clang's ASan RT library"
+    exit 1
+fi
+
+if ! ldconfig -p | grep -- "$ASAN_RT_PATH" >/dev/null; then
+    LDCONFIG_PATH="$(mktemp /etc/ld.so.conf.d/99-clang-libasan-XXX.conf)"
+    echo "Adding ${ASAN_RT_PATH%/*} to ldconfig cache (using $LDCONFIG_PATH)"
+    echo "${ASAN_RT_PATH%/*}" >"$LDCONFIG_PATH"
+    ldconfig
+
+    if ! ldconfig -p | grep -- "$ASAN_RT_PATH" >/dev/null; then
+        echo >&2 "Failed to add $ASAN_RT_PATH to ldconfig cache"
+        exit 1
+    fi
+fi
+
+# Compile systemd with the Address Sanitizer (ASan) and Undefined Behavior
+# Sanitizer (UBSan) using llvm/clang
+# FIXME (--as-needed)
+# Since version 10, both gcc and clang started to ignore certain linker errors
+# when compiling with -fsanitize=address. This eventually leads up to -lcrypt
+# not being correctly propagated, but the fact is masked by the aforementioned
+# issue. However, when the binary attempts to load a symbol from the libcrypt
+# binary, it crashes since it's not linked correctly against it.
+# Negating the -Wl,--as-needed used by default by -Wl,--no-as-needed seems to
+# help in this case.
+#
+# See:
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1827338#c3
+#   https://github.com/systemd/systemd-centos-ci/issues/247
+(
+    export CC=clang
+    export CXX=clang++
+    # Make sure we copy over the meson logs even if the compilation fails
+    # shellcheck disable=SC2064
+    trap "[[ -d $BUILD_DIR/meson-logs ]] && cp -r $BUILD_DIR/meson-logs '$LOGDIR'" EXIT
+    meson "$BUILD_DIR" \
+        -Dc_args='-Og -fno-omit-frame-pointer -ftrapv -shared-libasan' \
+        -Dc_link_args="-shared-libasan" \
+        -Dcpp_args='-Og -fno-omit-frame-pointer -ftrapv -shared-libasan' \
+        -Dcpp_link_args="-shared-libasan" \
+        -Db_asneeded=false `# See the FIXME (--as-needed) above` \
+        -Ddebug=true \
+        --werror \
+        -Dfuzz-tests=true \
+        -Dslow-tests=true \
+        -Dtests=unsafe \
+        -Dinstall-tests=true \
+        -Ddbuspolicydir=/etc/dbus-1/system.d \
+        -Dnobody-user=nfsnobody \
+        -Dnobody-group=nfsnobody \
+        -Dman=false \
+        -Db_sanitize=address,undefined \
+        -Db_lundef=false # See https://github.com/mesonbuild/meson/issues/764
+    ninja-build -C "$BUILD_DIR"
+) 2>&1 | tee "$LOGDIR/build-$(uname -m).log"
+
+# Manually install upstream D-Bus config file for org.freedesktop.network1
+# so systemd-networkd testsuite can use potentially new/updated methods
+cp -fv src/network/org.freedesktop.network1.conf /usr/share/dbus-1/system.d/
+
+# Manually install upstream systemd-networkd service unit files in case a PR
+# introduces a change in them
+# See: https://github.com/systemd/systemd/pull/14415#issuecomment-579307925
+cp -fv "$BUILD_DIR/units/systemd-networkd.service" /usr/lib/systemd/system/systemd-networkd.service
+cp -fv "$BUILD_DIR/units/systemd-networkd-wait-online.service" /usr/lib/systemd/system/systemd-networkd-wait-online.service
+
+# Support udevadm/systemd-udevd merge efforts from
+# https://github.com/systemd/systemd/pull/15918
+# The udevadm -> systemd-udevd symlink is created in the install phase which
+# we don't execute in sanitizer runs, so let's create it manually where
+# we need it
+if [[ -x "$BUILD_DIR/udevadm" && ! -x "$BUILD_DIR/systemd-udevd" ]]; then
+    ln -frsv "$BUILD_DIR/udevadm" "$BUILD_DIR/systemd-udevd"
+fi
+
+# Don't reboot the machine, since we don't install the sanitized build anyway,
+# due to stability reasons

--- a/agent/testsuite-alt.sh
+++ b/agent/testsuite-alt.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/bash
+# shellcheck disable=SC2155
+
+export BUILD_DIR="${BUILD_DIR:-/systemd-meson-build}"
+
+LIB_ROOT="$(dirname "$0")/../common"
+# shellcheck source=common/task-control.sh
+. "$LIB_ROOT/task-control.sh" "testsuite-logs-upstream-$(uname -m)" || exit 1
+# shellcheck source=common/utils.sh
+. "$LIB_ROOT/utils.sh" || exit 1
+
+# EXIT signal handler
+at_exit() {
+    set +e
+    exectask "journalctl-testsuite" "journalctl -b --no-pager"
+    [[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
+}
+
+trap at_exit EXIT
+
+### SETUP PHASE ###
+# Exit on error in the setup phase
+set -eu
+
+# Enable systemd-coredump
+if ! coredumpctl_init; then
+    echo >&2 "Failed to configure systemd-coredump/coredumpctl"
+    exit 1
+fi
+
+if [[ ! -f /usr/bin/ninja ]]; then
+    ln -s /usr/bin/ninja-build /usr/bin/ninja
+fi
+
+set +e
+
+### TEST PHASE ###
+pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
+
+## Sanitizer-specific options
+export ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_invalid_pointer_pairs=2:print_cmdline=1
+export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
+
+# Dump current ASan config
+ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}help=1" "$BUILD_DIR/systemctl" is-system-running &>"$LOGDIR/asan_config.txt"
+
+## Disable certain flaky tests
+# FIXME: test-execute
+# This test occasionally timeouts when running under sanitizers. Until the root
+# cause is figured out, let's temporarily skip this test to not disturb CI runs.
+echo 'int main(void) { return 77; }' > src/test/test-execute.c
+
+## FIXME: systemd-networkd testsuite: skip test_macsec
+# Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
+# dereference (and since 5.8.0 an additional oops). Since the issue hasn't been
+# looked at/fixed for over a month now, let's disable the failing test to
+# no longer block the CI image updates.
+# See: systemd/systemd#16199
+sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
+
+exectask "ninja-test_sanitizers_$(uname -m)" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
+exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"
+
+# As running integration tests with broken systemd can be quite time consuming
+# (usually we need to wait for the test to timeout, see $QEMU_TIMEOUT and
+# $NSPAWN_TIMEOUT above), let's try to sanity check systemd first by running
+# the basic integration test under systemd-nspawn
+#
+# If the sanity check passes we can be at least somewhat sure the systemd
+# 'core' is stable and we can run the rest of the selected integration tests.
+# 1) Run it under systemd-nspawn
+export TESTDIR="/var/tmp/TEST-01-BASIC_sanitizers-nspawn"
+rm -fr "$TESTDIR"
+exectask "TEST-01-BASIC_sanitizers-nspawn" "make -C test/TEST-01-BASIC clean setup run clean-again TEST_NO_QEMU=1 && touch $TESTDIR/pass"
+NSPAWN_EC=$?
+# Each integration test dumps the system journal when something breaks
+[[ ! -f "$TESTDIR/pass" ]] && rsync -aq "$TESTDIR/system.journal" "$LOGDIR/${TESTDIR##*/}/"
+
+if [[ $NSPAWN_EC -eq 0 ]]; then
+    # 2) The sanity check passed, let's run the other half of the TEST-01-BASIC
+    #    (under QEMU) and possibly other selected tests
+    export TESTDIR="/var/tmp/systemd-test-TEST-01-BASIC_sanitizers-qemu"
+    rm -fr "$TESTDIR"
+    exectask "TEST-01-BASIC_sanitizers-qemu" "make -C test/TEST-01-BASIC clean setup run TEST_NO_NSPAWN=1 && touch $TESTDIR/pass"
+
+    # Run the systemd-networkd testsuite "in the background" while we run other
+    # integration tests, since it doesn't require much resources and should not
+    # interfere with them (and vice versa), saving a non-insignificant amount
+    # of time
+    exectask_p "systemd-networkd_sanitizers" \
+               "/bin/time -v -- timeout -k 60s 60m test/test-network/systemd-networkd-tests.py --build-dir=$BUILD_DIR --debug --asan-options=$ASAN_OPTIONS --ubsan-options=$UBSAN_OPTIONS"
+
+    # Run certain other integration tests under sanitizers to cover bigger
+    # systemd subcomponents (but only if TEST-01-BASIC passed, so we can
+    # be somewhat sure the 'base' systemd components work).
+    EXECUTED_LIST=()
+    INTEGRATION_TESTS=(
+        test/TEST-04-JOURNAL        # systemd-journald
+        test/TEST-13-NSPAWN-SMOKE   # systemd-nspawn
+        test/TEST-15-DROPIN         # dropin logic
+        test/TEST-17-UDEV           # systemd-udevd
+        test/TEST-22-TMPFILES       # systemd-tmpfiles
+        test/TEST-23-TYPE-EXEC
+        test/TEST-29-PORTABLE       # systemd-portabled
+        test/TEST-34-DYNAMICUSERMIGRATE
+        test/TEST-46-HOMED          # systemd-homed
+        test/TEST-50-DISSECT        # systemd-dissect
+        test/TEST-54-CREDS          # credentials & stuff
+        test/TEST-55-OOMD           # systemd-oomd
+        test/TEST-58-REPART         # systemd-repart
+        test/TEST-65-ANALYZE        # systemd-analyze
+        test/TEST-72-SYSUPDATE      # systemd-sysupdate
+    )
+
+    for t in "${INTEGRATION_TESTS[@]}"; do
+        # Some of the newer tests might not be available in stable branches,
+        # so let's skip them instead of failing
+        if [[ ! -d "$t" ]]; then
+            echo "Test '$t' is not available, skipping..."
+            continue
+        fi
+
+        # Set the test dir to something predictable so we can refer to it later
+        export TESTDIR="/var/tmp/systemd-test-${t##*/}"
+
+        # Disable nested KVM for TEST-13-NSPAWN-SMOKE, which keeps randomly
+        # failing due to time outs caused by CPU soft locks. Also, bump the
+        # QEMU timeout, since the test is much slower without KVM.
+        export TEST_NESTED_KVM=yes
+        if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
+            unset TEST_NESTED_KVM
+            export QEMU_TIMEOUT=1200
+        fi
+
+        # Suffix the $TESTDIR of each retry with an index to tell them apart
+        export MANGLE_TESTDIR=1
+        exectask_retry "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass"
+
+        # Retried tasks are suffixed with an index, so update the $EXECUTED_LIST
+        # array accordingly to correctly find the respective journals
+        for ((i = 1; i <= EXECTASK_RETRY_DEFAULT; i++)); do
+            [[ -d "/var/tmp/systemd-test-${t##*/}_${i}" ]] && EXECUTED_LIST+=("${t}_${i}")
+        done
+    done
+
+    # Save journals created by integration tests
+    for t in "TEST-01-BASIC_sanitizers-qemu" "${EXECUTED_LIST[@]}"; do
+        testdir="/var/tmp/systemd-test-${t##*/}"
+        if [[ -f "$testdir/system.journal" ]]; then
+            # Filter out test-specific coredumps which are usually intentional
+            # Note: $COREDUMPCTL_EXCLUDE_MAP resides in common/utils.sh
+            # Note2: since all tests in this run are using the `exectask_retry`
+            #        runner, they're always suffixed with '_X'
+            if [[ -v "COREDUMPCTL_EXCLUDE_MAP[${t%_[0-9]}]" ]]; then
+                export COREDUMPCTL_EXCLUDE_RX="${COREDUMPCTL_EXCLUDE_MAP[${t%_[0-9]}]}"
+            fi
+            # Attempt to collect coredumps from test-specific journals as well
+            exectask "${t##*/}_coredumpctl_collect" "COREDUMPCTL_BIN='$BUILD_DIR/coredumpctl' coredumpctl_collect '$testdir/'"
+            # Make sure to not propagate the custom coredumpctl filter override
+            [[ -v COREDUMPCTL_EXCLUDE_RX ]] && unset -v COREDUMPCTL_EXCLUDE_RX
+
+            # Check for sanitizer errors in test journals
+            exectask "${t##*/}_sanitizer_errors" "$BUILD_DIR/journalctl -o short-monotonic --no-hostname --file $testdir/system.journal | check_for_sanitizer_errors"
+            # Keep the journal files only if the associated test case failed
+            if [[ ! -f "$testdir/pass" ]]; then
+                rsync -aq "$testdir/system.journal" "$LOGDIR/${t##*/}/"
+            fi
+        fi
+    done
+
+    exectask_p_finish
+    exectask "check-networkd-log-for-sanitizer-errors" "cat $LOGDIR/systemd-networkd_sanitizers*.log | check_for_sanitizer_errors"
+fi
+
+# Check the test logs for sanitizer errors as well, since some tests may
+# output the "interesting" information only to the console.
+_check_test_logs_for_sanitizer_errors() {
+    local ec=0
+
+    while read -r file; do
+        echo "*** Processing file $file ***"
+        check_for_sanitizer_errors < "$file" || ec=1
+    done < <(find "$LOGDIR" -maxdepth 1 -name "TEST-*.log" ! -name "*_sanitizer_*" ! -name "*_coredumpctl_*")
+
+    return $ec
+}
+exectask "test_logs_sanitizer_errors" "_check_test_logs_for_sanitizer_errors"
+exectask "check-journal-for-sanitizer-errors" "journalctl -b | check_for_sanitizer_errors"
+# Collect coredumps using the coredumpctl utility, if any
+exectask "coredumpctl_collect" "coredumpctl_collect"
+
+# Summary
+show_task_summary
+
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
Let's try to run tests on a sanitized build on newly supported alternative architectures.

TBD

---

[2020-12-09] There's no QEMU package for the ppc64le arch, and we can't run KVM there, since the machines are already virtualized, so the support for integration tests is not possible for now