### PR TITLE
Revert "vagrant: temporarily disable TEST-56-OOMD"

### DIFF
--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -73,7 +73,6 @@ SKIP_LIST=(
     "test/TEST-10-ISSUE-2467"       # Serialized below
     "test/TEST-16-EXTEND-TIMEOUT"   # flaky test
     "test/TEST-25-IMPORT"           # Serialized below
-    "test/TEST-56-OOMD"             # FIXME
 )
 
 for t in test/TEST-??-*; do


### PR DESCRIPTION
This reverts commit 983748e1ceb8a99855d880b3b0a3104ea0f64fe0.