### PR TITLE
vagrant: drop the ASan wrapper for test-execute

### DIFF
--- a/vagrant/vagrant-test-sanitizers.sh
+++ b/vagrant/vagrant-test-sanitizers.sh
@@ -53,30 +53,8 @@ echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
-## Temporary wrapper for `meson test` which disables LSan for `test-execute`
-# LSan keeps randomly crashing during `test-execute` so let's (temporarily)
-# disable it until we find out the culprit.
-# See:
-#   https://github.com/systemd/systemd-centos-ci/pull/217#issuecomment-580717687
-#   https://github.com/systemd/systemd/issues/14598
-ASAN_WRAPPER="$(mktemp "$BUILD_DIR/asan-wrapper-XXX.sh")"
-cat > "$ASAN_WRAPPER" << EOF
-#!/bin/bash
-
-export ASAN_OPTIONS=$ASAN_OPTIONS
-export UBSAN_OPTIONS=$UBSAN_OPTIONS
-
-if [[ \$(basename "\$1") == 'test-execute' ]]; then
-    ASAN_OPTIONS="\$ASAN_OPTIONS:detect_leaks=0"
-fi
-
-exec "\$@"
-EOF
-
-chmod +x "$ASAN_WRAPPER"
-
 # Run the internal unit tests (make check)
-exectask "ninja-test_sanitizers" "meson test -C $BUILD_DIR --wrapper=$ASAN_WRAPPER --print-errorlogs --timeout-multiplier=3"
+exectask "ninja-test_sanitizers" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 
 ## Run TEST-01-BASIC under sanitizers
 # Prepare a custom-tailored initrd image (with the systemd module included).


### PR DESCRIPTION
Reverts 6d7d22af5df1a8bca412ecc9d08628b42e8d0e4c