### PR TITLE
vagrant: unset the $TEST_NO_QEMU variable in each iteration

### DIFF
--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -126,6 +126,7 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         # TEST-13-NSPAWN-SMOKE causes spurious CPU soft lockups when run under
         # QEMU without KVM, so let's just run the nspawn part of the test
         # on the affected systems
+        unset TEST_NO_QEMU
         if [[ "$NESTED_KVM_ENABLED" == "n" && "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
             export TEST_NO_QEMU=1
         fi

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -86,6 +86,7 @@ for t in test/TEST-??-*; do
     # TEST-02-UNITTESTS and TEST-13-NSPAWN-SMOKE cause spurious CPU soft lockups
     # when run under  QEMU without KVM. Let's skip the QEMU part of these tests
     # on affected systems to make the CI less flaky
+    unset TEST_NO_QEMU
     if [[ "$NESTED_KVM_ENABLED" == "n" && "$t" =~ ^test/(TEST-02-UNITTESTS|TEST-13-NSPAWN-SMOKE)$ ]]; then
         export TEST_NO_QEMU=1
     fi


### PR DESCRIPTION
otherwise it remains set for following tests, causing unintended skips
of the respective QEMU parts.

Follow-up to d9cdbb9 and
48b8517.