### PR TITLE
agent/vagrant: skip test-journal-flush in TEST-02-UNITTESTS

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -48,6 +48,17 @@ if ! git diff --quiet master HEAD && ! git diff $(git merge-base master HEAD) --
     exit $FAILED
 fi
 
+# FIXME: test-journal-flush
+# A particularly ugly workaround for the flaky test-journal-flush. As the issue
+# presented so far only in the QEMU TEST-02, let's skip it just there, instead
+# of disabling it completely (even in the `meson test`). As the TEST-02 simply
+# makes a list of all test- prefixed files in the build directory, let's just
+# remove the offending test case, since we already executed it via `meson test`
+# above.
+#
+# See: systemd/systemd#17963
+rm -fv build/test-journal-flush
+
 ## Integration test suite ##
 SKIP_LIST=(
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -25,12 +25,19 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
-# Disable certain flaky tests
-# test-journal-flush: unstable on nested KVM
-echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
-
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
+
+# FIXME: test-journal-flush
+# A particularly ugly workaround for the flaky test-journal-flush. As the issue
+# presented so far only in the QEMU TEST-02, let's skip it just there, instead
+# of disabling it completely (even in the `meson test`). As the TEST-02 simply
+# makes a list of all test- prefixed files in the build directory, let's just
+# remove the offending test case, since we already executed it via `meson test`
+# above.
+#
+# See: systemd/systemd#17963
+rm -fv "$BUILD_DIR/test-journal-flush"
 
 ## FIXME: systemd-networkd testsuite: skip test_macsec
 # Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer


### PR DESCRIPTION
Since the issue has started appearing in the CentOS 7 runs as well,
let's tweak the existing workaround and extend it to both runs to make
the CI stable again, until a proper solution (with journal valiadation)
is implemented.

See: systemd/systemd#17963

Follow-up to a632f4f596530fbee7a71644cd98e5ba394fc21a.