### PR TITLE
agent/vagrant: skip test-journal-flush in TEST-02-UNITTESTS #2

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -51,13 +51,10 @@ fi
 # FIXME: test-journal-flush
 # A particularly ugly workaround for the flaky test-journal-flush. As the issue
 # presented so far only in the QEMU TEST-02, let's skip it just there, instead
-# of disabling it completely (even in the `meson test`). As the TEST-02 simply
-# makes a list of all test- prefixed files in the build directory, let's just
-# remove the offending test case, since we already executed it via `meson test`
-# above.
+# of disabling it completely (even in the `meson test`).
 #
 # See: systemd/systemd#17963
-rm -fv build/test-journal-flush
+sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -31,13 +31,10 @@ exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-mult
 # FIXME: test-journal-flush
 # A particularly ugly workaround for the flaky test-journal-flush. As the issue
 # presented so far only in the QEMU TEST-02, let's skip it just there, instead
-# of disabling it completely (even in the `meson test`). As the TEST-02 simply
-# makes a list of all test- prefixed files in the build directory, let's just
-# remove the offending test case, since we already executed it via `meson test`
-# above.
+# of disabling it completely (even in the `meson test`).
 #
 # See: systemd/systemd#17963
-rm -fv "$BUILD_DIR/test-journal-flush"
+sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
 
 ## FIXME: systemd-networkd testsuite: skip test_macsec
 # Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer


### PR DESCRIPTION
The actual workaround, because dumb me didn't realize the integration
tests use ninja/meson to install the build into a custom rootfs, thus
rebuilding the missing files, sigh.

Follow-up to 93829fcb5348ce5cb5f097d987f32a094ffaeb25.