### PR TITLE
agent/vagrant: reorder workarounds

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -35,6 +35,14 @@ set +e
 ### TEST PHASE ###
 pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
 
+# FIXME: test-journal-flush
+# A particularly ugly workaround for the flaky test-journal-flush. As the issue
+# presented so far only in the QEMU TEST-02, let's skip it just there, instead
+# of disabling it completely (even in the `meson test`).
+#
+# See: systemd/systemd#17963
+sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 # Copy over meson test artifacts
@@ -47,14 +55,6 @@ if ! git diff --quiet master HEAD && ! git diff $(git merge-base master HEAD) --
     echo "Detected man-only PR, skipping integration tests"
     exit $FAILED
 fi
-
-# FIXME: test-journal-flush
-# A particularly ugly workaround for the flaky test-journal-flush. As the issue
-# presented so far only in the QEMU TEST-02, let's skip it just there, instead
-# of disabling it completely (even in the `meson test`).
-#
-# See: systemd/systemd#17963
-sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -25,9 +25,6 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
-# Run the internal unit tests (make check)
-exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
-
 # FIXME: test-journal-flush
 # A particularly ugly workaround for the flaky test-journal-flush. As the issue
 # presented so far only in the QEMU TEST-02, let's skip it just there, instead
@@ -43,6 +40,9 @@ sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\
 # no longer block the CI image updates.
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
+
+# Run the internal unit tests (make check)
+exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 
 ## Integration test suite ##
 # Prepare a custom-tailored initrd image (with the systemd module included).


### PR DESCRIPTION
Move the recently introduced workarounds before the `meson test`
execution, otherwise the setup scripts of the integration tests will
trigger a partial ninja rebuild due to changed files, and because they
run in parallel bad things follow, like:

```
D: Install compiled systemd
+ DESTDIR=/var/tmp/systemd-test-TEST-01-BASIC/root
+ /sbin/ninja -C /systemd-meson-build install
ninja: Entering directory `/systemd-meson-build'
...
20/452] Generating systemd-bootx64.efi with a custom command
FAILED: src/boot/efi/systemd-bootx64.efi
/usr/bin/objcopy -j .text -j .sdata -j .data -j .dynamic -j .dynsym -j '.rel*' --target=efi-app-x86_64 src/boot/efi/systemd_boot.so src/boot/efi/systemd-bootx64.efi
/usr/bin/objcopy: error: the input file 'src/boot/efi/systemd_boot.so' is empty
```

and many more...