### PR TITLE
Tweak the image initialization

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -86,15 +86,8 @@ cp -fv "/boot/initramfs-$(uname -r).img" "$INITRD"
 # Rebuild the original initrd without the multipath module
 dracut -o multipath --rebuild "$INITRD"
 
-# The current revision of the integration test suite uses a set of base images
-# to reduce the overhead of building the same image over and over again.
-# However, this isn't compatible with parallelization & concurrent access.
-# To mitigate this, we need to run all tests with TEST_PARALLELIZE=1 (set below)
-# and to initialize the set of base images beforehand.
-if ! initialize_integration_tests "$PWD"; then
-    echo >&2 "Failed to initialize integration tests, can't continue..."
-    exit 1
-fi
+# Initialize the 'base' image (default.img) on which the other images are based
+exectask "setup-the-base-image" "make -C test/TEST-01-BASIC clean setup TESTDIR=/var/tmp/systemd-test-TEST-01-BASIC"
 
 for t in test/TEST-??-*; do
     if [[ ${#SKIP_LIST[@]} -ne 0 ]] && in_set "$t" "${SKIP_LIST[@]}"; then

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -56,15 +56,8 @@ if ! mkinitcpio -c /dev/null -A base,systemd,autodetect,modconf,block,filesystem
     exit 1
 fi
 
-# The current revision of the integration test suite uses a set of base images
-# to reduce the overhead of building the same image over and over again.
-# However, this isn't compatible with parallelization & concurrent access.
-# To mitigate this, we need to run all tests with TEST_PARALLELIZE=1 (set below)
-# and to initialize the set of base images beforehand.
-if ! initialize_integration_tests "$PWD"; then
-    echo >&2 "Failed to initialize integration tests, can't continue..."
-    exit 1
-fi
+# Initialize the 'base' image (default.img) on which the other images are based
+exectask "setup-the-base-image" "make -C test/TEST-01-BASIC clean setup TESTDIR=/var/tmp/systemd-test-TEST-01-BASIC"
 
 # Parallelized tasks
 SKIP_LIST=(


### PR DESCRIPTION
Since systemd/systemd@d9e606e each test use a base image which they
build on. However, with the current parallel test setup this introduces
a race condition, where each test tries to create the base image.

Let's initialize the base image separately and then run the rest of the
tests along with their setup phases.