### PR TITLE
common: collect & check all journals generated by exectask_retry()

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -64,6 +64,7 @@ if ! git diff --quiet main HEAD && ! git diff $(git merge-base main HEAD) --name
 fi
 
 ## Integration test suite ##
+EXECUTED_LIST=()
 FLAKE_LIST=(
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test, see below
     "test/TEST-50-DISSECT"        # flaky test, see below (systemd/systemd#17469)
@@ -124,6 +125,7 @@ for t in test/TEST-??-*; do
     rm -f "$TESTDIR/pass"
 
     exectask_p "${t##*/}" "make -C $t setup run && touch $TESTDIR/pass"
+    EXECUTED_LIST+=("$t")
 done
 
 # Wait for remaining running tasks
@@ -147,12 +149,15 @@ for t in "${FLAKE_LIST[@]}"; do
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
-    # Skipped test don't create the $TESTDIR automatically, so do it explicitly
-    # otherwise the `touch` command would fail
-    mkdir -p "$TESTDIR"
-    rm -f "$TESTDIR/pass"
-
-    exectask_retry "${t##*/}" "make -C $t setup run && touch $TESTDIR/pass"
+    # Suffix the $TESTDIR of each retry with an index to tell them apart
+    export MANGLE_TESTDIR=1
+    exectask_retry "${t##*/}" "make -C $t setup run && touch \$TESTDIR/pass"
+    # Retried tasks are suffixed with an index, so update the $EXECUTED_LIST
+    # array accordingly to correctly find the respective journals
+    for i in {1..3}; do
+        [[ ! -d "/var/tmp/systemd-test-${t##*/}_${i}" ]] && break
+        EXECUTED_LIST+=("${t}_${i}")
+    done
 done
 
 COREDUMPCTL_SKIP=(
@@ -161,8 +166,7 @@ COREDUMPCTL_SKIP=(
     "test/TEST-49-UDEV-EVENT-TIMEOUT"
 )
 
-# Save journals created by integration tests
-for t in test/TEST-??-*; do
+for t in "${EXECUTED_LIST[@]}"; do
     testdir="/var/tmp/systemd-test-${t##*/}"
     if [[ -f "$testdir/system.journal" ]]; then
         if ! in_set "$t" "${COREDUMPCTL_SKIP[@]}"; then
@@ -176,7 +180,7 @@ for t in test/TEST-??-*; do
     fi
 
     # Clean the no longer necessary test artifacts
-    make -C "$t" clean-again > /dev/null
+    [[ -d "$t" ]] && make -C "$t" clean-again > /dev/null
 done
 
 ## Other integration tests ##

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -179,6 +179,7 @@ exectask_retry() {
 
     local RETRIES="${3:-3}"
     local EC=0
+    local ORIG_TESTDIR
 
     for ((i = 1; i <= RETRIES; i++)); do
         local logfile="$LOGDIR/${1}_${i}.log"
@@ -188,6 +189,14 @@ exectask_retry() {
 
         echo "[TASK] $1 (try $i/$RETRIES)"
         echo "[TASK START] $(date)" >> "$logfile"
+
+        # Suffix the $TESTDIR for each retry by its index if requested
+        if [[ -v MANGLE_TESTDIR && "$MANGLE_TESTDIR" -ne 0 ]]; then
+            ORIG_TESTDIR="${ORIG_TESTDIR:-$TESTDIR}"
+            export TESTDIR="${ORIG_TESTDIR}_${i}"
+            mkdir -p "$TESTDIR"
+            rm -f "$TESTDIR/pass"
+        fi
 
         # shellcheck disable=SC2086
         eval $2 &>> "$logfile" &


### PR DESCRIPTION
This is a somewhat ugly solution to keep journals of all task retries
instead of just the last one.