### PR TITLE
tree-wide: check for coredumps in TEST-17-UDEV 

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -236,15 +236,17 @@ coredumpctl_collect() {
         ARGS+=(-D "$JOURNALDIR")
     fi
 
-    # Collect executable paths of all coredumps and filter out the expected ones
-    # FILTER_RX:
+    # Collect executable paths of all coredumps and filter out the expected ones.
+    # The filter can be overridden using the $COREDUMPCTL_EXCLUDE_RX env variable.
+    # EXCLUDE_RX:
     #   test-execute - certain subtests die with SIGSEGV intentionally
     #   dhcpcd - [temporary] keeps crashing intermittently with SIGABRT, needs
     #            further investigation
     #   python3.x - one of the test-execute subtests triggers SIGSYS in python3.x
     #               (since systemd/systemd#16675)
-    FILTER_RX="/(test-execute|dhcpcd|bin/python3.[0-9]+)$"
-    if ! "$COREDUMPCTL_BIN" "${ARGS[@]}" -F COREDUMP_EXE | grep -Ev "$FILTER_RX" > "$TEMPFILE"; then
+    local EXCLUDE_RX="${COREDUMPCTL_EXCLUDE_RX:-/(test-execute|dhcpcd|bin/python3.[0-9]+)$}"
+    _log "Excluding coredumps matching '$EXCLUDE_RX'"
+    if ! "$COREDUMPCTL_BIN" "${ARGS[@]}" -F COREDUMP_EXE | grep -Ev "$EXCLUDE_RX" > "$TEMPFILE"; then
         _log "No relevant coredumps found"
         return 0
     fi

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -136,20 +136,20 @@ for t in "${FLAKE_LIST[@]}"; do
     done
 done
 
-COREDUMPCTL_SKIP=(
-    # This test intentionally kills several processes using SIGABRT, thus generating
-    # cores which we're not interested in
-    "test/TEST-17-UDEV"
-)
-
 # Save journals created by integration tests
 for t in "${EXECUTED_LIST[@]}"; do
     testdir="/var/tmp/systemd-test-${t##*/}"
     if [[ -f "$testdir/system.journal" ]]; then
-        if ! in_set "$t" "${COREDUMPCTL_SKIP[@]}"; then
-            # Attempt to collect coredumps from test-specific journals as well
-            exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/'"
+        if [[ "$t" == "test/TEST-17-UDEV" ]]; then
+            # This test intentionally kills several processes using SIGABRT, thus
+            # generating cores which we're not interested in
+            export COREDUMPCTL_EXCLUDE_RX="/(sleep|udevadm)$"
         fi
+        # Attempt to collect coredumps from test-specific journals as well
+        exectask "${t##*/}_coredumpctl_collect" "coredumpctl_collect '$testdir/'"
+        # Make sure to not propagate the custom coredumpctl filter override
+        [[ -v COREDUMPCTL_EXCLUDE_RX ]] && unset -v COREDUMPCTL_EXCLUDE_RX
+
         # Keep the journal files only if the associated test case failed
         if [[ ! -f "$testdir/pass" ]]; then
             rsync -aq "$testdir/system.journal" "$LOGDIR/${t##*/}/"


### PR DESCRIPTION
This test was recently merged with other udev-related tests. However,
since one of them triggers a couple of coredumps, the coredumpctl_*
stuff was disabled for this particular test.

To ensure we don't miss any legit systemd-udevd coredumps, let's enable
the coredump checks, but explicitly exclude expected coredumps for certain
binaries using the recently introduced $COREDUMPCTL_EXCLUDE_RX variable.