### PR TITLE
common: dump the stack trace of all threads after reloading symbols

### DIFF
--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/bash
 
 set -u
+set -o pipefail
 
 # Internal logging helpers which make use of the internal call stack to get
 # the function name of the caller

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -203,7 +203,7 @@ coredumpctl_set_ts() {
 # Returns:
 #   0 when no coredumps were found, 1 otherwise
 coredumpctl_collect() {
-    local ARGS=(--no-legend --no-pager)
+    local ARGS=(-q --no-legend --no-pager)
     # Allow overriding the coredumpctl binary for cases when we read coredumps
     # from a custom directory, which may contain journals with different features
     # than are supported by the local journalctl/coredumpctl versions

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -2,6 +2,9 @@
 # shellcheck disable=SC2155
 # This file contains useful functions shared among scripts from this repository
 
+set -o pipefail
+set -u
+
 __COREDUMPCTL_TS=""
 
 # Internal logging helpers which make use of the internal call stack to get

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -270,7 +270,7 @@ coredumpctl_collect() {
             # $BUILD_DIR is set and we found the binary in it, let's override
             # the gdb command
             EXE="$BUILD_DIR/${path##*/}"
-            GDB_CMD="file $EXE\nframe\nbt full\nquit"
+            GDB_CMD="file $EXE\nthread apply all bt\nbt full\nquit"
             _log "\$BUILD_DIR is set and '${path##*/}' was found in it"
             _log "Overriding the executable to '$EXE' and gdb command to '$GDB_CMD'"
         fi

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -80,7 +80,7 @@ chmod +x "$ASAN_WRAPPER"
 
 # Run the internal unit tests (make check)
 exectask "ninja-test_sanitizers" "meson test -C $BUILD_DIR --wrapper=$ASAN_WRAPPER --print-errorlogs --timeout-multiplier=3"
-exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog.txt | check_for_sanitizer_errors"
+exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"
 
 ## Run TEST-01-BASIC under sanitizers
 # Prepare a custom-tailored initrd image (with the systemd module included).


### PR DESCRIPTION
If we end up loading symbols from a different binary (like in the sanitizer
runs), dump the stack trace of all threads to simulate the original
`coredumpctl info` format (which is in these cases useless, as it is
symbolized with a different binary).