### PR TITLE
vagrant: let's run even slow tests under sanitizers

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -68,8 +68,8 @@ fi
 yum -y install epel-release yum-utils gdb
 yum-config-manager --enable epel
 yum -y update
-yum -y install attr busybox dnsmasq e2fsprogs gcc-c++ libasan libbpf-devel libfdisk-devel nc net-tools ninja-build \
-               openssl-devel pcre2-devel python36 python-lxml qemu-kvm quota socat squashfs-tools strace \
+yum -y install attr busybox dnsmasq dosfstools e2fsprogs gcc-c++ libasan libbpf-devel libfdisk-devel nc net-tools \
+               ninja-build openssl-devel pcre2-devel python36 python-lxml qemu-kvm quota socat squashfs-tools strace \
                systemd-ci-environment veritysetup
 
 # Since systemd/systemd#13842 the minimal meson version was bumped to 0.52.1,

--- a/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-clang.sh
@@ -62,6 +62,7 @@ meson "$BUILD_DIR" \
       --optimization=g \
       -Dfexecve=true \
       -Dtests=unsafe \
+      -Dslow-tests=true \
       -Dfuzz-tests=true \
       -Dinstall-tests=true \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d \

--- a/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
+++ b/vagrant/bootstrap_scripts/arch-sanitizers-gcc.sh
@@ -59,6 +59,7 @@ meson "$BUILD_DIR" \
       --optimization=g \
       -Dfexecve=true \
       -Dtests=unsafe \
+      -Dslow-tests=true \
       -Dinstall-tests=true \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d \
       -Dman=false \

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
     # Install test dependencies
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
-    pacman --needed --noconfirm -S coreutils busybox dhclient dhcpcd diffutils dnsmasq e2fsprogs \
+    pacman --needed --noconfirm -S coreutils busybox dhclient dhcpcd diffutils dnsmasq dosfstools e2fsprogs \
         gdb inetutils net-tools openbsd-netcat qemu rsync socat squashfs-tools strace vi
 
     # Configure NTP (chronyd)


### PR DESCRIPTION
After a bit of manual testing it looks like all tests currently tagged
as 'slow' are capable of running under sanitizers without timeouts.