### PR TITLE
vagrant: use 'root' as the default user for `vagrant ssh`

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -68,7 +68,7 @@ fi
 yum -y install epel-release yum-utils gdb
 yum-config-manager --enable epel
 yum -y update
-yum -y install attr busybox dnsmasq e2fsprogs gcc-c++ libasan libbpf-devel libfdisk-devel nc net-tools \
+yum -y install attr busybox dnsmasq dosfstools e2fsprogs gcc-c++ libasan libbpf-devel libfdisk-devel nc net-tools \
                ninja-build openssl-devel pcre2-devel python36 python-lxml qemu-kvm quota socat squashfs-tools strace \
                systemd-ci-environment veritysetup
 

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -55,6 +55,14 @@ sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\
 # See: systemd/systemd#17078
 echo 'int main(void) { return 77; }' > src/test/test-seccomp.c
 
+# FIXME: test-loop-block
+# This test is flaky due to uevent mess, and requires a kernel change.
+#
+# See:
+#   systemd/systemd#17469
+#   systemd/systemd#18166
+echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 # Copy over meson test artifacts

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -48,6 +48,14 @@ fi
 # test-journal-flush: unstable on nested KVM
 echo 'int main(void) { return 77; }' > src/journal/test-journal-flush.c
 
+# FIXME: test-loop-block
+# This test is flaky due to uevent mess, and requires a kernel change.
+#
+# See:
+#   systemd/systemd#17469
+#   systemd/systemd#18166
+echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
+
 ## FIXME: systemd-networkd testsuite: skip test_macsec
 # Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
 # dereference (and since 5.8.0 an additional oops). Since the issue hasn't been

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -37,6 +37,14 @@ pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 # shellcheck disable=SC2016
 sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
 
+# FIXME: test-loop-block
+# This test is flaky due to uevent mess, and requires a kernel change.
+#
+# See:
+#   systemd/systemd#17469
+#   systemd/systemd#18166
+echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
+
 ## FIXME: systemd-networkd testsuite: skip test_macsec
 # Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
 # dereference (and since 5.8.0 an additional oops). Since the issue hasn't been

--- a/vagrant/vagrant-build.sh
+++ b/vagrant/vagrant-build.sh
@@ -120,7 +120,7 @@ if $USING_SANITIZERS; then
     # Skip the reboot/reload when running with sanitizers, as it in most cases
     # causes boot to timeout or die completely
     # Run tests with sanitizers
-    vagrant ssh -c "cd /build && sudo $RELATIVE_TEST_DIR/${TEST_SCRIPT##*/} $DISTRO_STRING"
+    vagrant ssh -c "cd /build && $RELATIVE_TEST_DIR/${TEST_SCRIPT##*/} $DISTRO_STRING"
     SSH_EC=$?
 else
     # Reboot the VM to "apply" the new systemd
@@ -138,7 +138,7 @@ else
             ;;
     esac
     # Run tests
-    vagrant ssh -c "cd /build && sudo $RELATIVE_TEST_DIR/${TEST_SCRIPT##*/} $DISTRO_STRING"
+    vagrant ssh -c "cd /build && $RELATIVE_TEST_DIR/${TEST_SCRIPT##*/} $DISTRO_STRING"
     SSH_EC=$?
 fi
 

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -25,6 +25,14 @@ Vagrant.configure("2") do |config|
     mount_options: ["rw", "async", "fsc", "rsize=32768", "wsize=32768",
                     "hard", "noatime", "actimeo=2"]
 
+  # Set the default user for `vagrant ssh` to root and insert the Vagrant's
+  # SSH key to allow passwordless SSH login. This requires the SSH account
+  # to be unlocked, have its password set to 'vagrant', and the PermitRootLogin=
+  # directive in /etc/ssh/sshd_config set to 'yes'.
+  config.ssh.username = "root"
+  config.ssh.password = "vagrant"
+  config.ssh.insert_key = "true"
+
   # Note: CentOS CI infra specific overrides - you may want to change them
   #       to run the VM locally
   config.vm.provider :libvirt do |libvirt|

--- a/vagrant/vagrantfiles/Vagrantfile_rawhide
+++ b/vagrant/vagrantfiles/Vagrantfile_rawhide
@@ -25,6 +25,14 @@ Vagrant.configure("2") do |config|
     mount_options: ["rw", "async", "fsc", "rsize=32768", "wsize=32768",
                     "hard", "noatime", "actimeo=2"]
 
+  # Set the default user for `vagrant ssh` to root and insert the Vagrant's
+  # SSH key to allow passwordless SSH login. This requires the SSH account
+  # to be unlocked, have its password set to 'vagrant', and the PermitRootLogin=
+  # directive in /etc/ssh/sshd_config set to 'yes'.
+  config.ssh.username = "root"
+  config.ssh.password = "vagrant"
+  config.ssh.insert_key = "true"
+
   config.vm.provider :libvirt do |libvirt|
     libvirt.driver = ENV.fetch("VAGRANT_DRIVER", "kvm")
     libvirt.memory = ENV.fetch("VAGRANT_MEMORY", "8192")


### PR DESCRIPTION
This should allow us run tests which require $XDG_RUNTIME_DIR and/or
$DBUS_SESSION_BUS_ADDRESS to be set correctly, since `sudo` nor `su`
does that.