### PR TITLE
agent: use the "correct" netcat version on CentOS 8

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -50,23 +50,40 @@ set -e -u
 set -o pipefail
 
 ADDITIONAL_DEPS=(
+    dnsmasq
+    e2fsprogs
+    gdb
     libasan
     libubsan
     make
     net-tools
+    nmap-ncat
     perl-IPC-SysV
     perl-Time-HiRes
     qemu-kvm
+    quota
+    socat
     strace
+    wget
 )
 
 # Install and enable EPEL
-dnf -y install epel-release "${ADDITIONAL_DEPS[@]}"
-dnf config-manager --enable epel
+dnf -y install epel-release dnf-plugins-core
+dnf config-manager --enable epel --enable powertools
 # Upgrade the machine to get the most recent environment
 dnf -y upgrade
 # Install systemd's build dependencies
-dnf -y --enablerepo "powertools" builddep systemd
+dnf -y builddep systemd
+dnf -y install "${ADDITIONAL_DEPS[@]}"
+# As busybox is not shipped in RHEL 8/CentOS 8 anymore, we need to get it
+# using a different way. Needed by TEST-13-NSPAWN-SMOKE
+wget -O /usr/bin/busybox https://www.busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-x86_64 && chmod +x /usr/bin/busybox
+# Use the Nmap's version of nc, since TEST-13-NSPAWN-SMOKE doesn't seem to work
+# with the OpenBSD version present on CentOS 8
+if alternatives --display nmap; then
+    alternatives --set nmap /usr/bin/ncat
+    alternatives --display nmap
+fi
 
 # Fetch the systemd repo
 test -e systemd && rm -rf systemd

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -55,15 +55,6 @@ if [[ $(cat /proc/sys/user/max_user_namespaces) -le 0 ]]; then
     exit 1
 fi
 
-# Install test dependencies
-exectask "dnf-depinstall" \
-    "dnf -y install dnsmasq e2fsprogs gdb nc net-tools qemu-kvm quota socat strace wget"
-
-# As busybox is not shipped in RHEL 8/CentOS 8 anymore, we need to get it
-# using a different way. Needed by TEST-13-NSPAWN-SMOKE
-exectask "install-busybox" \
-    "wget -O /bin/busybox https://www.busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-x86_64 && chmod +x /bin/busybox"
-
 set +e
 
 ### TEST PHASE ###


### PR DESCRIPTION
netcat is now provided by two packages (nmap-ncat from AppStream and
netcat from EPEL), but TEST-13 works only with nmap-ncat. Let's make
sure we use the correct version.

Also, move the dep installation into the bootstrap script to keep it in
one place.