### PR TITLE
agent: collect coredumps before reboot as well

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -99,6 +99,12 @@ if setenforce 0; then
     echo SELINUX=disabled >/etc/selinux/config
 fi
 
+# Enable systemd-coredump
+if ! coredumpctl_init; then
+    echo >&2 "Failed to configure systemd-coredump/coredumpctl"
+    exit 1
+fi
+
 # Compile systemd
 #   - slow-tests=true: enable slow tests
 #   - tests=unsafe: enable unsafe tests, which might change the environment
@@ -240,6 +246,10 @@ grubby --args="user_namespace.enable=1 $CGROUP_KERNEL_ARGS" --update-kernel="$(g
 grep -r "user_namespace.enable=1" /boot/loader/entries/
 grep -r "systemd.unified_cgroup_hierarchy" /boot/loader/entries/
 echo "user.max_user_namespaces=10000" >> /etc/sysctl.conf
+
+# coredumpctl_collect takes an optional argument, which upsets shellcheck
+# shellcheck disable=SC2119
+coredumpctl_collect
 
 echo "-----------------------------"
 echo "- REBOOT THE MACHINE BEFORE -"

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -106,6 +106,12 @@ fi
 # Disable firewalld (needed for systemd-networkd tests)
 systemctl disable firewalld
 
+# Enable systemd-coredump
+if ! coredumpctl_init; then
+    echo >&2 "Failed to configure systemd-coredump/coredumpctl"
+    exit 1
+fi
+
 # Compile & install libbpf-next
 (
     git clone --depth=1 https://github.com/libbpf/libbpf libbpf
@@ -241,6 +247,10 @@ for arg in "${GRUBBY_ARGS[@]}"; do
         exit 1
     fi
 done
+
+# coredumpctl_collect takes an optional argument, which upsets shellcheck
+# shellcheck disable=SC2119
+coredumpctl_collect
 
 # Let's leave this here for a while for debugging purposes
 echo "Current date:         $(date)"


### PR DESCRIPTION
In several cases (one pretty recent) systemd crashed during
daemon-reexec done before reboot and the reboot never happened. To catch
this scenario as well, try to collect any possible coredumps before
rebooting the machine, so we have at least something actionable if it
hapens.