### PR TITLE
common: ignore sleep instead of bash coredumps

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -247,8 +247,8 @@ coredumpctl_collect() {
     #            further investigation
     #   python3.x - one of the test-execute subtests triggers SIGSYS in python3.x
     #               (since systemd/systemd#16675)
-    #   bash - intentional SIGABRT caused by TEST-57
-    local EXCLUDE_RX="${COREDUMPCTL_EXCLUDE_RX:-/(test-execute|dhcpcd|bin/python3.[0-9]+|platform-python3.[0-9]+|bash)$}"
+    #   sleep - intentional SIGABRT caused by TEST-57
+    local EXCLUDE_RX="${COREDUMPCTL_EXCLUDE_RX:-/(test-execute|dhcpcd|bin/python3.[0-9]+|platform-python3.[0-9]+|sleep)$}"
     _log "Excluding coredumps matching '$EXCLUDE_RX'"
     if ! "$COREDUMPCTL_BIN" "${ARGS[@]}" -F COREDUMP_EXE | grep -Ev "$EXCLUDE_RX" > "$TEMPFILE"; then
         _log "No relevant coredumps found"


### PR DESCRIPTION
PR systemd/systemd#19336 was updated and now it's
/usr/bin/sleep which gets a sigabort:

```
13:29:04 [coredumpctl_collect] Excluding coredumps matching '/(test-execute|dhcpcd|bin/python3.[0-9]+|platform-python3.[0-9]+|bash)$'
13:29:04 [coredumpctl_collect] Gathering coredumps for '/usr/bin/sleep'
13:29:04            PID: 165086 (sleep)
13:29:04            UID: 0 (root)
13:29:04            GID: 0 (root)
13:29:04         Signal: 6 (ABRT)
13:29:04      Timestamp: Mon 2021-04-19 13:40:31 CEST (48min ago)
13:29:04   Command Line: sleep 5
13:29:04     Executable: /usr/bin/sleep
13:29:04  Control Group: /machine.slice/TEST-57-RELOADING-RESTART.scope/payload/system.slice/testservice-abort-restart-57.service
13:29:04           Unit: TEST-57-RELOADING-RESTART.scope
13:29:04          Slice: machine.slice
13:29:04        Boot ID: 47f48ec1dda642778d3d76eefd448433
13:29:04     Machine ID: 38c91a39779b4b41821ae4599826b26d
13:29:04       Hostname: systemd-testsuite
13:29:04        Storage: /var/lib/systemd/coredump/core.sleep.0.47f48ec1dda642778d3d76eefd448433.165086.1618832431000000.zst (present)
13:29:04      Disk Size: 15.7K
13:29:04        Message: Process 165086 (sleep) of user 0 dumped core.
13:29:04
13:29:04                 Found module linux-vdso.so.1 with build-id: bfe6a86807f7ef96351aa61ca2b7ba72a242cb9f
13:29:04                 Found module ld-linux-x86-64.so.2 with build-id: 21aaf1e283785c50056573fe07ba780170b42ed5
13:29:04                 Found module libc.so.6 with build-id: 54a6e404e7dc1de7c1434a00b7b1ad325b81f22a
13:29:04                 Found module sleep with build-id: df363af3dd283ffcadfefa4d42e942870fcd63e1
13:29:04                 Stack trace of thread 75:
13:29:04                 #0  0x00007f353ed870da clock_nanosleep@@GLIBC_2.17 (libc.so.6 + 0xc70da)
13:29:04                 #1  0x00007f353ed8c357 __nanosleep (libc.so.6 + 0xcc357)
13:29:04                 #2  0x000055fd73ac44c8 n/a (sleep + 0x54c8)
13:29:04                 #3  0x000055fd73ac4282 n/a (sleep + 0x5282)
13:29:04                 #4  0x000055fd73ac1251 n/a (sleep + 0x2251)
13:29:04                 #5  0x00007f353ece7b25 __libc_start_main (libc.so.6 + 0x27b25)
13:29:04                 #6  0x000055fd73ac132e n/a (sleep + 0x232e)
```

https://jenkins-systemd.apps.ocp.ci.centos.org/job/upstream-vagrant-archlinux/4090/console