### PR TITLE
agent/vagrant: install libbpf from repository instead of manual build

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -123,6 +123,7 @@ fi
     pushd libbpf/src
     LD_FLAGS="-Wl,--no-as-needed" NO_PKG_CONFIG=1 make
     make install
+    ldconfig
     popd
     rm -fr libbpf
 )

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -57,6 +57,7 @@ Vagrant.configure("2") do |config|
     pushd libbpf/src
     LD_FLAGS="-Wl,--no-as-needed" NO_PKG_CONFIG=1 make
     make install
+    ldconfig
     popd
     rm -fr libbpf
 


### PR DESCRIPTION
@mrc0mmand is this enough to install the libbpf package in the image too? Context: https://github.com/systemd/systemd/pull/19705