### PR TITLE
vagrant: run TEST-36-NUMAPOLICY under sanitizers

### DIFF
--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -151,6 +151,7 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         test/TEST-17-UDEV           # systemd-udevd
         test/TEST-22-TMPFILES       # systemd-tmpfiles
         test/TEST-29-PORTABLE       # systemd-portabled
+        test/TEST-36-NUMAPOLICY     # this test tests journald as a "side effect"
         test/TEST-46-HOMED          # systemd-homed
         test/TEST-50-DISSECT        # systemd-dissect
         test/TEST-55-OOMD           # systemd-oomd


### PR DESCRIPTION
This test inadvertently tests systemd-journald by using a lot of cursors
and other journald-specific stuff, stumbling across interesting issues,
like systemd/systemd#19895.