### PR TITLE
agent/rhel8: skip test-journal-flush under QEMU

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -60,6 +60,15 @@ set +e
 ### TEST PHASE ###
 pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
 
+# FIXME: test-journal-flush
+# A particularly ugly workaround for the flaky test-journal-flush. As the issue
+# presented so far only in the QEMU TEST-24, let's skip it just there, instead
+# of disabling it completely (even in the `meson test`).
+#
+# See: systemd/systemd#17963
+# shellcheck disable=SC2016
+sed -i '/TEST_LIST=/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/TEST-24-UNIT-TESTS/testsuite.sh
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 # Copy over meson test artifacts


### PR DESCRIPTION
Essentially the same scenario as in 93829fc and 76a69b4, but for
RHEL/CentOS 8 job.