### PR TITLE
vagrant: use btrfs-aware packages to tweak Fedora images

### DIFF
--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -39,6 +39,14 @@ if [[ "${VAGRANT_FILE##*/}" == "Vagrantfile_rawhide_selinux" ]]; then
     echo "Using '$BOX_NAME' as the Fedora Rawhide box name"
 
     sed -i "/config.vm.box_url/s/BOX-NAME-PLACEHOLDER/$BOX_NAME/" "$VAGRANT_FILE"
+
+    # FIXME: since F34 Fedora uses btrfs as the default FS, which causes errors
+    #        when re-boxing such image, since CentOS 8 doesn't understand btrfs.
+    #        Let's workaround this by using a couple of custom packages, which
+    #        were rebuilt to make them "btrfs-aware".
+    echo "[WORKAROUND] Installing btrfs-aware packages"
+    dnf -y copr enable mrc0mmand/epel8-btrfs-playground
+    dnf -y install btrfs-progs kernel-5.12.4 libguestfs-tools-c
 fi
 
 # Disable SELinux on the test hosts and avoid false positives.


### PR DESCRIPTION
Since F34 Fedora uses btrfs as the default FS, which causes errors[0]
when re-boxing such image, since CentOS 8 doesn't understand btrfs.
Let's workaround this by using a couple of custom packages, which
were rebuilt to make them "btrfs-aware".

[0]
```
==> rawhide_selinux: Packaging domain...
==> rawhide_selinux: Downloading vagrant-cache-MzSmg_rawhide_selinux.img to /root/vagrant-cache-MzSmg/_tmp_package/box.img
==> rawhide_selinux: Image has backing image, copying image and rebasing ...
virt-sysprep: error: libguestfs error: inspect_os: mount exited with status
32: mount: /tmp/btrfs0jA5db: unknown filesystem type 'btrfs'.
```