### PR TITLE
vagrant: disable nested KVM for TEST-13-NSPAWN-SMOKE w/ sanitizers

### DIFF
--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -144,6 +144,15 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         # Set the test dir to something predictable so we can refer to it later
         export TESTDIR="/var/tmp/systemd-test-${t##*/}"
 
+        # Disable nested KVM for TEST-13-NSPAWN-SMOKE, which keeps randomly
+        # failing due to time outs caused by CPU soft locks. Also, bump the
+        # QEMU timeout, since the test is much slower without KVM.
+        export TEST_NESTED_KVM=yes
+        if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
+            unset TEST_NESTED_KVM
+            export QEMU_TIMEOUT=1200
+        fi
+
         # Suffix the $TESTDIR of each retry with an index to tell them apart
         export MANGLE_TESTDIR=1
         exectask_retry "${t##*/}" "make -C $t setup run && touch \$TESTDIR/pass"


### PR DESCRIPTION
The test keeps randomly failing due to spurious timeouts caused by CPU
soft lockups. Since this happens only with this specific test (and also
only under sanitizers), disable nested KVM just for it.

```
[  252.675662] kernel: watchdog: BUG: soft lockup - CPU#3 stuck for 27s! [systemd:1]
[  252.678963] kernel: Modules linked in: ext4 crc32c_generic crc16 mbcache jbd2 sr_mod cdrom ata_generic pata_acpi serio_raw atkbd libps2 ata_piix floppy crc32c_intel i8042 serio
[  252.678963] kernel: CPU: 3 PID: 1 Comm: systemd Not tainted 5.12.14-arch1-1 #1
[  252.678963] kernel: Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS ArchLinux 1.14.0-1 04/01/2014
[  252.678963] kernel: RIP: 0010:__do_softirq+0x79/0x2c1
[  252.678963] kernel: Code: 81 67 2c ff f7 ff ff be 00 01 00 00 e8 c0 f5 2c ff c7 44 24 10 0a 00 00 00 65 66 c7 05 4e bf 22 64 00 00 fb 66 0f 1f 44 00 00 <b8> ff ff ff ff 49 c7 c3 c0 60 a0 9c 41 0f bc c7 89 c5 83 c5 01 74
[  252.678963] kernel: RSP: 0000:ffffb1c240013ee8 EFLAGS: 00000246
[  252.678963] kernel: RAX: 0000000000000000 RBX: 0000000000000000 RCX: 00000034a18f012f
[  252.678963] kernel: RDX: 0000000000000151 RSI: 00000034a18f012f RDI: ffffffffffce473c
[  252.678963] kernel: RBP: ffffb1c240013f58 R08: 00000034a18f0280 R09: 7fffffffffffffff
[  252.678963] kernel: R10: 0000003499f00282 R11: 0000000019e86899 R12: 0000000000000000
[  252.678963] kernel: R13: 0000000000000000 R14: 0000000000000000 R15: 0000000000000282
[  252.678963] kernel: FS:  00007fca49688b00(0000) GS:ffff9c6b7d580000(0000) knlGS:0000000000000000
[  252.678963] kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  252.678963] kernel: CR2: 0000624000073000 CR3: 000000000462a001 CR4: 0000000000170ee0
[  252.678963] kernel: Call Trace:
[  252.678963] kernel:  irq_exit_rcu+0x9e/0xd0
[  252.678963] kernel:  sysvec_apic_timer_interrupt+0x3c/0x90
[  252.678963] kernel:  ? asm_sysvec_apic_timer_interrupt+0xa/0x20
[  252.678963] kernel:  asm_sysvec_apic_timer_interrupt+0x12/0x20
[  252.678963] kernel: RIP: 0033:0x7fca4adccf3b
[  252.678963] kernel: Code: 48 c7 c0 ea ff ff ff 48 83 c4 08 5b 41 5c 41 5d 41 5e 41 5f 5d c3 48 89 df e8 31 6e c6 ff 90 55 48 89 e5 e8 07 00 00 00 85 c0 <0f> 94 c0 5d c3 55 48 89 e5 48 85 ff 74 0c 48 85 f6 74 07 e8 8d 40
[  252.678963] kernel: RSP: 002b:00007ffca0af7840 EFLAGS: 00000286
[  252.678963] kernel: RAX: 00000000ffffffff RBX: 00007fca4b2c4888 RCX: 00000000ffffffff
[  252.678963] kernel: RDX: 0000603000038876 RSI: 00007fca4b18f840 RDI: 00007fca4adccf53
[  252.678963] kernel: RBP: 00007ffca0af7840 R08: 0000000000000001 R09: 00000ff9c962a628
[  252.678963] kernel: R10: 00007fca4b18f840 R11: 000060300003887c R12: 0000603000038876
[  252.678963] kernel: R13: 00007fca4b2c4880 R14: 0000000000000001 R15: 000000000000000b
...
[  258.220428] testsuite-13.sh[1389]: (sd-namespace) succeeded.
[  258.220428] testsuite-13.sh[1389]: Init process invoked as PID 1392
[  258.229415] testsuite-13.sh[1389]: Bus n/a: changing state UNSET → OPENING
[  258.229415] testsuite-13.sh[1389]: sd-bus: starting bus by connecting to /run/dbus/system_bus_socket...
[  258.229415] testsuite-13.sh[1389]: Bus n/a: changing state OPENING → AUTHENTICATING
[  258.229415] testsuite-13.sh[1389]: Bus n/a: changing state AUTHENTICATING → HELLO
[  258.229415] testsuite-13.sh[1389]: Failed to allocate scope: Connection timed out
```