### PR TITLE
vagrant: compile & install tgt (iSCSI target utils)

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -61,6 +61,16 @@ Vagrant.configure("2") do |config|
     popd
     rm -fr libbpf
 
+    # Compile & install tgt (iSCSI target utils)
+    pacman --needed --noconfirm -S docbook-xsl libxslt perl-config-general
+    git clone https://github.com/fujita/tgt tgt
+    pushd tgt
+    make sbindir=/usr/bin ISCSI=1
+    make sbindir=/usr/bin install
+    install -Dm644 scripts/tgtd.service /usr/lib/systemd/system/tgtd.service
+    popd
+    rm -fr tgt
+
     # Disable 'quiet' mode on the kernel command line and forward everything
     # to ttyS0 instead of just tty0, so we can collect it using QEMU's
     # -serial file:xxx feature. Also, explicitly enable unified cgroups, since


### PR DESCRIPTION
Unfortunately, this package is not available in Arch repositories (only
AUR), so let's build it ourselves.