### PR TITLE
Revert "vagrant: temporarily disable the deprecated-declarations check"

### DIFF
--- a/vagrant/bootstrap_scripts/rawhide-selinux.sh
+++ b/vagrant/bootstrap_scripts/rawhide-selinux.sh
@@ -36,12 +36,9 @@ rpm -qa > vagrant-rawhide-installed-pkgs.txt
 
 rm -fr "$BUILD_DIR"
 # Build phase
-# FIXME: temporarily disable the deprecated-declarations check to allow building
-#        with OpenSSL 3.x
-# See: https://github.com/systemd/systemd/issues/20775
 meson "$BUILD_DIR" \
       --werror \
-      -Dc_args='-fno-omit-frame-pointer -ftrapv -Wno-deprecated-declarations' \
+      -Dc_args='-fno-omit-frame-pointer -ftrapv' \
       -Ddebug=true \
       --optimization=g \
       -Dtests=true \


### PR DESCRIPTION
This reverts commit 9c76fc7dff4c2b68e6df20299d05a9fec6acf62e.

Fixed by https://github.com/systemd/systemd/pull/20876