### PR TITLE
tree-wide: use lowercase for local variables

### DIFF
--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -176,14 +176,14 @@ fi
 # Check the test logs for sanitizer errors as well, since some tests may
 # output the "interesting" information only to the console.
 _check_test_logs_for_sanitizer_errors() {
-    local EC=0
+    local ec=0
 
     while read -r file; do
         echo "*** Processing file $file ***"
-        check_for_sanitizer_errors < "$file" || EC=1
+        check_for_sanitizer_errors < "$file" || ec=1
     done < <(find "$LOGDIR" -maxdepth 1 -name "TEST-*.log" ! -name "*_sanitizer_*" ! -name "*_coredumpctl_*")
 
-    return $EC
+    return $ec
 }
 exectask "test_logs_sanitizer_errors" "_check_test_logs_for_sanitizer_errors"
 


### PR DESCRIPTION
Follow-up to 475025c11b40c15a80ec7534d26f32022b3003c3.