### PR TITLE
Revert "vagrant: temporarily pin the vagrant-libvirt plugin version"

### DIFF
--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -80,9 +80,7 @@ if ! vagrant plugin list | grep vagrant-libvirt; then
     export GEM_HOME=~/.vagrant.d/gems
     export GEM_PATH=$GEM_HOME:/opt/vagrant/embedded/gems
     export PATH=/opt/vagrant/embedded/bin:$PATH
-    # FIXME: vagrant-libvirt v0.6.0 introduced a couple of regressions; let's
-    #        pin its version until they're resolved
-    vagrant plugin install vagrant-libvirt --plugin-version "0.5.3"
+    vagrant plugin install vagrant-libvirt
 fi
 
 vagrant --version


### PR DESCRIPTION
This reverts commit 715264f6ce0fbe35df587ef1c4e53e71dc7fa4fa.

Fixed in vagrant-libvirt 0.6.1.

See:
  * https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1376
  * https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1377