### PR TITLE
vagrant: collect coverage from the $BUILD_DIR

### DIFF
--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -194,8 +194,10 @@ systemctl reload dbus.service
 systemctl enable --now dhcpcd@eth0.service
 systemctl status dhcpcd@eth0.service
 
-# Delete coverage metadata left over by unit/integration tests
-lcov_clear_metadata "$BUILD_DIR"
+# Collect coverage metadata from the $BUILD_DIR (since we use the just-built nspawn
+# and other tools)
+exectask "lcov_build_dir_collect" "lcov_collect $COVERAGE_DIR/build_dir.coverage-info $BUILD_DIR && lcov_clear_metadata $BUILD_DIR"
+
 # Tweak $BUILD_DIR's permissions, since networkd and resolved run under unprivileged
 # users and wouldn't be able to generate coverage reports
 chmod -R o+rwX "$BUILD_DIR"


### PR DESCRIPTION
Since we use the just-built nspawn (and a couple of other built systemd
tools), let's actually collect the respective coverage instead of
discarding it.