### PR TITLE
vagrant: temporarily disable one of the test-execute's subtests

### DIFF
--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -59,6 +59,16 @@ echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
+# FIXME: test-execute
+# Kernel 5.15 introduced an change in the API which breaks one of the subtests.
+# Drop this change once either the test is tweaked for this change or the change
+# is reconsidered in kernel.
+#
+# See:
+#   systemd/systemd#21087
+#   https://github.com/torvalds/linux/commit/e70344c05995a190a56bbd1a23dc2218bcc8c924
+sed -i '/exec-ioschedulingclass-none.service/d' src/test/test-execute.c
+
 exectask "ninja-test" "GCOV_ERROR_FILE=$LOGDIR/ninja-test-gcov-errors.log meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "ninja-test-collect-coverage" "lcov_collect $COVERAGE_DIR/unit-tests.coverage-info $BUILD_DIR && lcov_clear_metadata $BUILD_DIR"
 

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -50,6 +50,16 @@ echo 'int main(void) { return 77; }' > src/test/test-execute.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
+# FIXME: test-execute
+# Kernel 5.15 introduced an change in the API which breaks one of the subtests.
+# Drop this change once either the test is tweaked for this change or the change
+# is reconsidered in kernel.
+#
+# See:
+#   systemd/systemd#21087
+#   https://github.com/torvalds/linux/commit/e70344c05995a190a56bbd1a23dc2218bcc8c924
+sed -i '/exec-ioschedulingclass-none.service/d' src/test/test-execute.c
+
 # Run the internal unit tests (make check)
 exectask "ninja-test_sanitizers" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -53,6 +53,16 @@ echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
+# FIXME: test-execute
+# Kernel 5.15 introduced an change in the API which breaks one of the subtests.
+# Drop this change once either the test is tweaked for this change or the change
+# is reconsidered in kernel.
+#
+# See:
+#   systemd/systemd#21087
+#   https://github.com/torvalds/linux/commit/e70344c05995a190a56bbd1a23dc2218bcc8c924
+sed -i '/exec-ioschedulingclass-none.service/d' src/test/test-execute.c
+
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 


### PR DESCRIPTION
`test_exec_ioschedulingclass.exec-ioschedulingclass-none.service` from
`test-execute` keeps failing since kernel 5.15 due to a change in the
kernel API. Until the issue is resolved (on either side), let's skip the
test to not disturb the CI.

See: systemd/systemd#21087