### PR TITLE
Revert "vagrant: temporarily disable one of the test-execute's subtests"

### DIFF
--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -59,16 +59,6 @@ echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
-# FIXME: test-execute
-# Kernel 5.15 introduced an change in the API which breaks one of the subtests.
-# Drop this change once either the test is tweaked for this change or the change
-# is reconsidered in kernel.
-#
-# See:
-#   systemd/systemd#21087
-#   https://github.com/torvalds/linux/commit/e70344c05995a190a56bbd1a23dc2218bcc8c924
-sed -i '/exec-ioschedulingclass-none.service/d' src/test/test-execute.c
-
 exectask "ninja-test" "GCOV_ERROR_FILE=$LOGDIR/ninja-test-gcov-errors.log meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "ninja-test-collect-coverage" "lcov_collect $COVERAGE_DIR/unit-tests.coverage-info $BUILD_DIR && lcov_clear_metadata $BUILD_DIR"
 

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -50,16 +50,6 @@ echo 'int main(void) { return 77; }' > src/test/test-execute.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
-# FIXME: test-execute
-# Kernel 5.15 introduced an change in the API which breaks one of the subtests.
-# Drop this change once either the test is tweaked for this change or the change
-# is reconsidered in kernel.
-#
-# See:
-#   systemd/systemd#21087
-#   https://github.com/torvalds/linux/commit/e70344c05995a190a56bbd1a23dc2218bcc8c924
-sed -i '/exec-ioschedulingclass-none.service/d' src/test/test-execute.c
-
 # Run the internal unit tests (make check)
 exectask "ninja-test_sanitizers" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -53,16 +53,6 @@ echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
 # See: systemd/systemd#16199
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 
-# FIXME: test-execute
-# Kernel 5.15 introduced an change in the API which breaks one of the subtests.
-# Drop this change once either the test is tweaked for this change or the change
-# is reconsidered in kernel.
-#
-# See:
-#   systemd/systemd#21087
-#   https://github.com/torvalds/linux/commit/e70344c05995a190a56bbd1a23dc2218bcc8c924
-sed -i '/exec-ioschedulingclass-none.service/d' src/test/test-execute.c
-
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 


### PR DESCRIPTION
This reverts commit bb79a5d4b3efb4b6fca18d0c4501a3154c12db0e.

See: systemd/systemd#21503