### PR TITLE
agent/vagrant: re-enable test-journal-flush

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -39,15 +39,6 @@ set +e
 ### TEST PHASE ###
 pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
 
-# FIXME: test-journal-flush
-# A particularly ugly workaround for the flaky test-journal-flush. As the issue
-# presented so far only in the QEMU TEST-02, let's skip it just there, instead
-# of disabling it completely (even in the `meson test`).
-#
-# See: systemd/systemd#17963
-# shellcheck disable=SC2016
-sed -i '/mapfile -t TEST_LIST/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
-
 # FIXME: test-loop-block
 # This test is flaky due to uevent mess, and requires a kernel change.
 #

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -34,15 +34,6 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
-# FIXME: test-journal-flush
-# A particularly ugly workaround for the flaky test-journal-flush. As the issue
-# presented so far only in the QEMU TEST-02, let's skip it just there, instead
-# of disabling it completely (even in the `meson test`).
-#
-# See: systemd/systemd#17963
-# shellcheck disable=SC2016
-sed -i '/mapfile -t TEST_LIST/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
-
 # FIXME: test-loop-block
 # This test is flaky due to uevent mess, and requires a kernel change.
 #

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -28,15 +28,6 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
-# FIXME: test-journal-flush
-# A particularly ugly workaround for the flaky test-journal-flush. As the issue
-# presented so far only in the QEMU TEST-02, let's skip it just there, instead
-# of disabling it completely (even in the `meson test`).
-#
-# See: systemd/systemd#17963
-# shellcheck disable=SC2016
-sed -i '/mapfile -t TEST_LIST/aTEST_LIST=("${TEST_LIST[@]/\\/usr\\/lib\\/systemd\\/tests\\/test-journal-flush}")' test/units/testsuite-02.sh
-
 # FIXME: test-loop-block
 # This test is flaky due to uevent mess, and requires a kernel change.
 #


### PR DESCRIPTION
The flakiness should be, hopefully, fixed by systemd/systemd#21529.