### PR TITLE
agent: reexec the user daemon as well (RHEL 8)

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -329,7 +329,11 @@ class AgentControl():
         An exception if the waiting timeout is reached
         """
         logging.info("Rebooting node %s", node)
-        self.execute_remote_command(node, "systemctl reboot", 255, ignore_rc=True)
+        self.execute_remote_command(
+                node,
+                "systemd-analyze set-log-level debug; systemd-analyze set-log-target console; systemctl reboot",
+                255,
+                ignore_rc=True)
         time.sleep(30)
 
         self.wait_for_node(node, 10)

--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -232,6 +232,7 @@ fi
 # the old systemd binary was incompatible with the unit files on disk and
 # prevented the system from reboot
 SYSTEMD_LOG_LEVEL=debug systemctl daemon-reexec
+SYSTEMD_LOG_LEVEL=debug systemctl --user daemon-reexec
 
 # The systemd testsuite uses the ext4 filesystem for QEMU virtual machines.
 # However, the ext4 module is not included in initramfs by default, because


### PR DESCRIPTION
Should, hopefully, fix the CI fail in https://github.com/redhat-plumbers/systemd-rhel8/pull/213.