### PR TITLE
vagrant(selinux): temporarily disable the deprecated-declarations check

### DIFF
--- a/vagrant/bootstrap_scripts/rawhide-selinux.sh
+++ b/vagrant/bootstrap_scripts/rawhide-selinux.sh
@@ -36,9 +36,12 @@ rpm -qa > vagrant-rawhide-installed-pkgs.txt
 
 rm -fr "$BUILD_DIR"
 # Build phase
+# FIXME: temporarily disable the deprecated-declarations check to allow building
+#        with OpenSSL 3.x
+# See: https://github.com/systemd/systemd/issues/20775
 meson "$BUILD_DIR" \
       --werror \
-      -Dc_args='-fno-omit-frame-pointer -ftrapv' \
+      -Dc_args='-fno-omit-frame-pointer -ftrapv -Wno-deprecated-declarations' \
       -Ddebug=true \
       --optimization=g \
       -Dtests=true \


### PR DESCRIPTION
to allow building with OpenSSL 3.x (again).

See: https://github.com/systemd/systemd/pull/21170#issuecomment-985505461