### PR TITLE
tree-wide: install `screen` required by TEST-69-SHUTDOWN

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -72,6 +72,7 @@ ADDITIONAL_DEPS=(
     qrencode-devel
     quota
     rust
+    screen
     scsi-target-utils
     selinux-policy-devel
     socat

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -39,8 +39,8 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S coreutils busybox dhclient dhcp dhcpcd diffutils dnsmasq dosfstools e2fsprogs \
-        gdb inetutils lcov libdwarf libelf net-tools openbsd-netcat open-iscsi qemu rsync socat squashfs-tools strace vi \
-        wireguard-tools
+        gdb inetutils lcov libdwarf libelf net-tools openbsd-netcat open-iscsi qemu rsync screen socat squashfs-tools \
+        strace vi wireguard-tools
 
     # Unlock root account and set its password to 'vagrant' to allow root login
     # via ssh


### PR DESCRIPTION
See: systemd/systemd#21838