### PR TITLE
vagrant(arch): install `python-pexpect` required by TEST-69-SHUTDOWN

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -39,8 +39,8 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S coreutils busybox dhclient dhcp dhcpcd diffutils dnsmasq dosfstools e2fsprogs \
-        gdb inetutils lcov libdwarf libelf net-tools openbsd-netcat open-iscsi qemu rsync screen socat squashfs-tools \
-        strace vi wireguard-tools
+        gdb inetutils lcov libdwarf libelf net-tools openbsd-netcat open-iscsi python-pexpect qemu rsync screen socat \
+        squashfs-tools strace vi wireguard-tools
 
     # Unlock root account and set its password to 'vagrant' to allow root login
     # via ssh


### PR DESCRIPTION
See: systemd/systemd#21838

Follow-up to ec8068b4054c6af737d9f2e470058c18237b1a41.