### PR TITLE
tree-wide: use the new repo mirror path

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -89,7 +89,7 @@ cmd_retry dnf -y config-manager --enable epel --enable powertools
 # See: https://sigs.centos.org/kmods/repositories/
 cmd_retry dnf -y install centos-release-kmods
 # Local mirror of https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci-centos8/
-cmd_retry dnf -y config-manager --add-repo "http://artifacts.ci.centos.org/systemd/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
+cmd_retry dnf -y config-manager --add-repo "https://jenkins-systemd.apps.ocp.ci.centos.org/job/centos8-reposync/lastSuccessfulBuild/artifact/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
 # FIXME: workaround for broken "private" mirrors served via metalink API
 while read -r repofile; do
     sed -i '/^metalink/s/metalink/mirrorlist/g' "$repofile"

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -90,10 +90,6 @@ cmd_retry dnf -y config-manager --enable epel --enable powertools
 cmd_retry dnf -y install centos-release-kmods
 # Local mirror of https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci-centos8/
 cmd_retry dnf -y config-manager --add-repo "https://jenkins-systemd.apps.ocp.ci.centos.org/job/centos8-reposync/lastSuccessfulBuild/artifact/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
-# FIXME: workaround for broken "private" mirrors served via metalink API
-while read -r repofile; do
-    sed -i '/^metalink/s/metalink/mirrorlist/g' "$repofile"
-done < <(find /etc/yum.repos.d -name "epel*.repo")
 cmd_retry dnf -y update
 cmd_retry dnf -y builddep systemd
 cmd_retry dnf -y install "${ADDITIONAL_DEPS[@]}"

--- a/vagrant/bootstrap_scripts/rawhide-selinux.sh
+++ b/vagrant/bootstrap_scripts/rawhide-selinux.sh
@@ -36,12 +36,9 @@ rpm -qa > vagrant-rawhide-installed-pkgs.txt
 
 rm -fr "$BUILD_DIR"
 # Build phase
-# FIXME: temporarily disable the deprecated-declarations check to allow building
-#        with OpenSSL 3.x
-# See: https://github.com/systemd/systemd/issues/20775
 meson "$BUILD_DIR" \
       --werror \
-      -Dc_args='-fno-omit-frame-pointer -ftrapv -Wno-deprecated-declarations' \
+      -Dc_args='-fno-omit-frame-pointer -ftrapv' \
       -Ddebug=true \
       --optimization=g \
       -Dtests=true \

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -59,15 +59,6 @@ fi
 if ! vagrant plugin list | grep vagrant-libvirt; then
     # Install vagrant-libvirt dependencies
     dnf -y install gcc libguestfs-tools-c libvirt libvirt-devel libgcrypt make qemu-kvm ruby-devel
-
-    # FIXME?: install newer qemu-kvm
-    dnf -y install dnf-plugins-core
-    # Local mirror of https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci-centos8/
-    dnf -y config-manager --add-repo "https://jenkins-systemd.apps.ocp.ci.centos.org/job/centos8-reposync/lastSuccessfulBuild/artifact/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
-    # Note: make sure the repo with newer qemu has "module_hotfixes=true", otherwise
-    # the packages will be shadowed by qemu from the virt module
-    dnf -y update qemu-kvm
-
     # Start libvirt daemon
     systemctl start libvirtd
     systemctl status libvirtd

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -63,7 +63,7 @@ if ! vagrant plugin list | grep vagrant-libvirt; then
     # FIXME?: install newer qemu-kvm
     dnf -y install dnf-plugins-core
     # Local mirror of https://copr.fedorainfracloud.org/coprs/mrc0mmand/systemd-centos-ci-centos8/
-    dnf -y config-manager --add-repo "http://artifacts.ci.centos.org/systemd/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
+    dnf -y config-manager --add-repo "https://jenkins-systemd.apps.ocp.ci.centos.org/job/centos8-reposync/lastSuccessfulBuild/artifact/repos/mrc0mmand-systemd-centos-ci-centos8-stream8/mrc0mmand-systemd-centos-ci-centos8-stream8.repo"
     # Note: make sure the repo with newer qemu has "module_hotfixes=true", otherwise
     # the packages will be shadowed by qemu from the virt module
     dnf -y update qemu-kvm


### PR DESCRIPTION
introduced in de2aa4b713f95fea2e133f8cfd9e18906fec3f14.