### PR TITLE
Revert "agent: disable test-watchdog on C9S"

### DIFF
--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -84,13 +84,6 @@ echo 'int main(void) { return 77; }' > src/test/test-seccomp.c
 #   https://github.com/systemd/systemd/commit/a1e3f0f38b43e68ff9ea33ab1935aed4edf6ed7f
 echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 
-# FIXME: test-watchdog
-# One of the chassis has (most likely) broken HW watchdog, causing unexpected
-# reboots.
-#
-# See: https://pagure.io/centos-infra/issue/505
-echo 'int main(void) { return 77; }' > src/test/test-watchdog.c
-
 # Run the internal unit tests (make check)
 # Note: All .dusty.* servers have Intel Xeon CPUs with 4 cores and HT enabled
 #       which causes issues when the machine is under heavy load (in this case


### PR DESCRIPTION
This reverts commit e58bb66.

Fixed by https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/177.