### PR TITLE
vagrant(arch): install & start GDM by default

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
     # Install build dependencies
     # Package groups: base, base-devel
     pacman --needed --noconfirm -S base base-devel bpf btrfs-progs acl audit bash-completion clang compiler-rt docbook-xsl \
-        ethtool git gnu-efi-libs gperf intltool iptables kexec-tools kmod libcap libelf libfido2 libgcrypt libidn2 \
+        ethtool gdm git gnu-efi-libs gperf intltool iptables kexec-tools kmod libcap libelf libfido2 libgcrypt libidn2 \
         libmicrohttpd libpwquality libseccomp libutil-linux libxkbcommon libxslt linux-api-headers llvm llvm-libs lvm2 lz4 \
         meson multipath-tools ninja p11-kit pam pcre2 python-jinja python-lxml qrencode quota-tools rust tpm2-pkcs11 xz
     # Install test dependencies
@@ -51,6 +51,9 @@ Vagrant.configure("2") do |config|
     pacman --needed --noconfirm -S chrony
     systemctl enable --now chronyd
     systemctl status chronyd
+
+    # Enable GDM by default (to catch certain systemd-logind related issues)
+    systemctl enable gdm.service
 
     # Compile & install libbpf-next
     pacman --needed --noconfirm -S elfutils libelf


### PR DESCRIPTION
to catch (or at least attempt to) some systemd-logind related issues.