### PR TITLE
vagrant(arch): explicitly set the default target to graphical.target

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -54,6 +54,8 @@ Vagrant.configure("2") do |config|
 
     # Enable GDM by default (to catch certain systemd-logind related issues)
     systemctl enable gdm.service
+    systemctl set-default graphical.target
+    systemctl get-default
 
     # Compile & install libbpf-next
     pacman --needed --noconfirm -S elfutils libelf


### PR DESCRIPTION
Follow-up to 7bfc86e3cc8e93b5d950541afe82e267e20a6602.