### PR TITLE
vagrant(coverage): set the default ACL for the build dir

### DIFF
--- a/vagrant/bootstrap_scripts/arch-coverage.sh
+++ b/vagrant/bootstrap_scripts/arch-coverage.sh
@@ -51,7 +51,6 @@ meson "$BUILD_DIR" \
       -Dinstall-tests=true \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d
 ninja -C "$BUILD_DIR"
-ninja -C "$BUILD_DIR" install
 
 # Install cpp-coveralls to generate the Coveralls-compatible report
 # See: https://github.com/eddyxu/cpp-coveralls
@@ -60,6 +59,16 @@ python3 -m ensurepip
 # https://github.com/eddyxu/cpp-coveralls/pull/165 is merged/resolved
 python3 -m pip install git+https://github.com/mrc0mmand/cpp-coveralls@send-correct-ids
 #python3 -m pip install cpp-coveralls
+
+# Manually install upstream D-Bus config file for org.freedesktop.network1
+# so systemd-networkd testsuite can use potentially new/updated methods
+cp -fv src/network/org.freedesktop.network1.conf /usr/share/dbus-1/system.d/
+
+# Manually install upstream systemd-networkd service unit files in case a PR
+# introduces a change in them
+# See: https://github.com/systemd/systemd/pull/14415#issuecomment-579307925
+cp -fv "$BUILD_DIR/units/systemd-networkd.service" /usr/lib/systemd/system/systemd-networkd.service
+cp -fv "$BUILD_DIR/units/systemd-networkd-wait-online.service" /usr/lib/systemd/system/systemd-networkd-wait-online.service
 
 # In order to be able to collect all coverage reports, we need to run
 # the systemd-networkd test suite from the build dir, which means we need to

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -192,7 +192,7 @@ exectask "lcov_build_dir_collect" "lcov_collect $COVERAGE_DIR/build_dir.coverage
 
 # Tweak $BUILD_DIR's permissions, since networkd and resolved run under unprivileged
 # users and wouldn't be able to generate coverage reports
-chmod -R o+rwX "$BUILD_DIR"
+setfacl -R -m 'd:o:rwX' -m 'o:rwX' "$BUILD_DIR"
 exectask "systemd-networkd" \
          "timeout -k 60s 60m test/test-network/systemd-networkd-tests.py --build-dir=$BUILD_DIR --debug --with-coverage"
 exectask "lcov_networkd_collect_coverage" "lcov_collect $COVERAGE_DIR/systemd-networkd.coverage-info $BUILD_DIR && lcov_clear_metadata $BUILD_DIR"


### PR DESCRIPTION
to account for newly created directories by gcov.

(This could be done with sticky bits as well, but using ACLs feels more
readable.)