### PR TITLE
common: override the # of CPUs and queue size on *.dusty machines

### DIFF
--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -38,6 +38,16 @@ else
     OPTIMAL_QEMU_SMP=${OPTIMAL_QEMU_SMP:-1}
 fi
 
+if ! systemd-detect-virt -vq && [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]]; then
+    # All dusty machines have Intel Xeon CPUs with 4 cores and HT enabled,
+    # which causes issues when the HT cores are counted as "real" ones, namely
+    # CPU over-saturation and strange hangups. As all dusty server have the
+    # same HW, let's manually override the # of CPUs for the VM to 4.
+    _log "Running on a *.dusty machine, overriding the # of CPUs to 4 and queue size to 1"
+    MAX_QUEUE_SIZE=1
+    OPTIMAL_QEMU_SMP=4
+fi
+
 echo "[TASK-CONTROL] OPTIMAL_QEMU_SMP = $OPTIMAL_QEMU_SMP"
 echo "[TASK-CONTROL] MAX_QUEUE_SIZE = $MAX_QUEUE_SIZE"
 


### PR DESCRIPTION
All dusty machines have Intel Xeon CPUs with 4 cores and HT enabled,
which causes issues when the HT cores are counted as "real" ones, namely
CPU over-saturation and strange hangups. As all dusty server have the
same HW, let's manually override the # of CPUs for the VM to 4.

Even though this will make the jobs running on the affected machines
slower it should make them more reliable, which outweighs the runtime
penalty.

Resolves: #477
Follow-up to: 8003bcee22890981e0cf13ee37cc5675403a4863