### PR TITLE
vagrant: disable the default /vagrant rsync'ed folder

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -18,6 +18,8 @@ Vagrant.configure("2") do |config|
     libvirt.random :model => 'random'
   end
 
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -e
 

--- a/vagrant/boxes/Vagrantfile_rawhide_selinux
+++ b/vagrant/boxes/Vagrantfile_rawhide_selinux
@@ -19,6 +19,8 @@ Vagrant.configure("2") do |config|
     libvirt.random :model => 'random'
   end
 
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -e
 


### PR DESCRIPTION
since we don't use it anyway and it causes weird issues with the recent
Rawhide boxes.