### PR TITLE
tree-wide: significantly reduce the amount tests marked as 'flaky'

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -39,14 +39,6 @@ set +e
 ### TEST PHASE ###
 pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
 
-# FIXME: test-loop-block
-# This test is flaky due to uevent mess, and requires a kernel change.
-#
-# See:
-#   systemd/systemd#17469
-#   systemd/systemd#18166
-echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
-
 # FIXME: test-seccomp
 # This test became flaky once again, so disable it temporarily until the reason
 # is found out.

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -78,9 +78,6 @@ fi
 EXECUTED_LIST=()
 FLAKE_LIST=(
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test, see below
-    "test/TEST-29-PORTABLE"       # flaky test, see below (systemd/systemd#17469)
-    "test/TEST-50-DISSECT"        # flaky test, see below (systemd/systemd#17469)
-    "test/TEST-58-REPART"         # flaky test, see below (yet another instance of systemd/systemd#17469)
 )
 SKIP_LIST=(
     "test/TEST-61-UNITTESTS-QEMU" # redundant test, runs the same tests as TEST-02, but only QEMU (systemd/systemd#19969)

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -66,7 +66,6 @@ FLAKE_LIST=(
     "test/TEST-10-ISSUE-2467"     # flaky test
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
     "test/TEST-25-IMPORT"         # flaky when paralellized (systemd/systemd#13973)
-    "test/TEST-55-OOMD"           # flaky test (systemd/systemd#21146)
 )
 SKIP_LIST=(
     "test/TEST-61-UNITTESTS-QEMU" # redundant test, runs the same tests as TEST-02, but only QEMU (systemd/systemd#19969)

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -66,10 +66,7 @@ FLAKE_LIST=(
     "test/TEST-10-ISSUE-2467"     # flaky test
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
     "test/TEST-25-IMPORT"         # flaky when paralellized (systemd/systemd#13973)
-    "test/TEST-29-PORTABLE"       # flaky test (systemd/systemd#17469)
-    "test/TEST-50-DISSECT"        # flaky test (systemd/systemd#17469)
     "test/TEST-55-OOMD"           # flaky test (systemd/systemd#21146)
-    "test/TEST-58-REPART"         # flaky test, see below (systemd/systemd#19442)
 )
 SKIP_LIST=(
     "test/TEST-61-UNITTESTS-QEMU" # redundant test, runs the same tests as TEST-02, but only QEMU (systemd/systemd#19969)

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -34,14 +34,6 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
-# FIXME: test-loop-block
-# This test is flaky due to uevent mess, and requires a kernel change.
-#
-# See:
-#   systemd/systemd#17469
-#   systemd/systemd#18166
-echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
-
 ## FIXME: systemd-networkd testsuite: skip test_macsec
 # Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
 # dereference (and since 5.8.0 an additional oops). Since the issue hasn't been

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -29,14 +29,6 @@ export UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1
 ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}help=1" "$BUILD_DIR/systemctl" is-system-running &>"$LOGDIR/asan_config.txt"
 
 ## Disable certain flaky tests
-# FIXME: test-loop-block
-# This test is flaky due to uevent mess, and requires a kernel change.
-#
-# See:
-#   systemd/systemd#17469
-#   systemd/systemd#18166
-echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
-
 # FIXME: test-execute
 # This test occasionally timeouts when running under sanitizers. Until the root
 # cause is figured out, let's temporarily skip this test to not disturb CI runs.

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -28,14 +28,6 @@ fi
 
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
-# FIXME: test-loop-block
-# This test is flaky due to uevent mess, and requires a kernel change.
-#
-# See:
-#   systemd/systemd#17469
-#   systemd/systemd#18166
-echo 'int main(void) { return 77; }' > src/test/test-loop-block.c
-
 ## FIXME: systemd-networkd testsuite: skip test_macsec
 # Since kernel 5.7.2 the macsec module is broken, causing a runtime NULL pointer
 # dereference (and since 5.8.0 an additional oops). Since the issue hasn't been

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -60,10 +60,7 @@ FLAKE_LIST=(
     "test/TEST-10-ISSUE-2467"     # flaky test
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
     "test/TEST-25-IMPORT"         # flaky when paralellized (systemd/systemd#13973)
-    "test/TEST-29-PORTABLE"       # flaky test (systemd/systemd#17469)
-    "test/TEST-50-DISSECT"        # flaky test (systemd/systemd#17469)
     "test/TEST-55-OOMD"           # flaky test (systemd/systemd#21146)
-    "test/TEST-58-REPART"         # flaky test, see below (systemd/systemd#19442)
 )
 SKIP_LIST=(
     "test/TEST-61-UNITTESTS-QEMU" # redundant test, runs the same tests as TEST-02, but only QEMU (systemd/systemd#19969)

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -60,7 +60,6 @@ FLAKE_LIST=(
     "test/TEST-10-ISSUE-2467"     # flaky test
     "test/TEST-16-EXTEND-TIMEOUT" # flaky test
     "test/TEST-25-IMPORT"         # flaky when paralellized (systemd/systemd#13973)
-    "test/TEST-55-OOMD"           # flaky test (systemd/systemd#21146)
 )
 SKIP_LIST=(
     "test/TEST-61-UNITTESTS-QEMU" # redundant test, runs the same tests as TEST-02, but only QEMU (systemd/systemd#19969)


### PR DESCRIPTION
Thanks to https://github.com/systemd/systemd/pull/22992 many of such tests should be now stable.