### PR TITLE
vagrant(arch): downgrade QEMU to 6.2.0

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -91,6 +91,17 @@ Vagrant.configure("2") do |config|
     popd
     rm -fr dfuzzer
 
+    # FIXME: downgrade QEMU to 6.2.0
+    # See: https://bugs.archlinux.org/task/74716
+    useradd makepkg
+    pacman --needed --noconfirm -S binutils fakeroot fzf pacman-contrib make
+    pacman -Syy
+    su makepkg -c 'cd /tmp && git clone https://aur.archlinux.org/downgrade.git && cd downgrade && makepkg'
+    pacman --noconfirm -U /tmp/downgrade/*.zst
+    pacman --noconfirm -R qemu-base
+    echo y | downgrade --maxdepth 2 --ala-only 'qemu=6.2.0-4' -- --noconfirm --overwrite \*
+    userdel -rf makepkg
+
     # Disable 'quiet' mode on the kernel command line and forward everything
     # to ttyS0 instead of just tty0, so we can collect it using QEMU's
     # -serial file:xxx feature. Also, explicitly enable unified cgroups, since

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -83,12 +83,11 @@ Vagrant.configure("2") do |config|
     rm -fr tgt
 
     # Compile & install dfuzzer
-    pacman --needed --noconfirm -S glib2 libffi make pkg-config
-    git clone https://github.com/matusmarhefka/dfuzzer dfuzzer
-    pushd dfuzzer/src
-    make
-    install -pm 0755 dfuzzer /usr/bin/dfuzzer
-    install -pm 0644 dfuzzer.conf /etc/dfuzzer.conf
+    pacman --needed --noconfirm -S docbook-xsl gcc glib2 libxslt meson pkg-config
+    git clone https://github.com/dbus-fuzzer/dfuzzer dfuzzer
+    pushd dfuzzer
+    meson build
+    ninja -C build install
     popd
     rm -fr dfuzzer
 


### PR DESCRIPTION
Revert once https://bugs.archlinux.org/task/74716 is resolved.