### PR TITLE
tree-wide: move summary into a separate function

### DIFF
--- a/agent/testsuite-rhel7.sh
+++ b/agent/testsuite-rhel7.sh
@@ -78,20 +78,6 @@ for t in "${TEST_LIST[@]}"; do
 done
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
+show_task_summary
 
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
-
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -174,20 +174,6 @@ if [[ $COLLECT_COREDUMPS -ne 0 ]]; then
 fi
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
+show_task_summary
 
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
-
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/agent/testsuite-rhel9-sanitizers.sh
+++ b/agent/testsuite-rhel9-sanitizers.sh
@@ -234,20 +234,6 @@ exectask "check-journal-for-sanitizer-errors" "journalctl -o short-monotonic --n
 exectask "coredumpctl_collect" "coredumpctl_collect"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
+show_task_summary
 
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
-
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -243,20 +243,6 @@ done
 exectask "coredumpctl_collect" "coredumpctl_collect"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
+show_task_summary
 
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
-
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -211,20 +211,6 @@ done
 exectask "coredumpctl_collect" "coredumpctl_collect"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
+show_task_summary
 
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
-
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -281,3 +281,24 @@ exectask_p_finish() {
         unset "TASK_QUEUE[$key]"
     done
 }
+
+# Show summary about executed tasks
+show_task_summary() {
+    local task
+
+    echo
+    echo "TEST SUMMARY:"
+    echo "-------------"
+    echo "PASSED: $PASSED"
+    echo "FAILED: $FAILED"
+    echo "TOTAL:  $((PASSED + FAILED))"
+
+    if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
+        echo
+        echo "FAILED TASKS:"
+        echo "-------------"
+        for task in "${FAILED_LIST[@]}"; do
+            echo "$task"
+        done
+    fi
+}

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -223,23 +223,9 @@ _check_for_missing_coverage() {
 exectask "check_for_missing_coverage" "_check_for_missing_coverage"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
-
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
+show_task_summary
 
 [[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -212,23 +212,9 @@ exectask "check-journal-for-sanitizer-errors" "journalctl -o short-monotonic --n
 exectask "coredumpctl_collect" "coredumpctl_collect"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
-
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
+show_task_summary
 
 [[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -180,23 +180,9 @@ done
 exectask "coredumpctl_collect" "coredumpctl_collect"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
-
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
+show_task_summary
 
 [[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/vagrant/test_scripts/test-rawhide-selinux.sh
+++ b/vagrant/test_scripts/test-rawhide-selinux.sh
@@ -31,22 +31,8 @@ exectask "selinux-status" "sestatus -v -b"
 exectask "avc-check" "! ausearch -m avc -i --start boot | audit2why"
 
 # Summary
-echo
-echo "TEST SUMMARY:"
-echo "-------------"
-echo "PASSED: $PASSED"
-echo "FAILED: $FAILED"
-echo "TOTAL:  $((PASSED + FAILED))"
-
-if [[ ${#FAILED_LIST[@]} -ne 0 ]]; then
-    echo
-    echo "FAILED TASKS:"
-    echo "-------------"
-    for task in "${FAILED_LIST[@]}"; do
-        echo "$task"
-    done
-fi
+show_task_summary
 
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
-exit $FAILED
+[[ $FAILED -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
to reduce code duplication. Also, set the exit code explicitly, since in
the future we might run more than 255 tasks which would overflow the
uint16 value for exit, causing unexpected passes (e.g. 256 fails == exit
code 0).