### PR TITLE
vagrant: install nfs-utils & ntp

### DIFF
--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -41,8 +41,8 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S coreutils bind busybox dhclient dhcp dhcpcd diffutils dnsmasq dosfstools e2fsprogs evemu \
-        gdb inetutils knot lcov libdwarf libelf net-tools openbsd-netcat open-iscsi python-pexpect qemu rsync screen socat \
-        squashfs-tools strace time tpm2-tools swtpm vi wireguard-tools
+        gdb inetutils knot lcov libdwarf libelf net-tools nfs-utils ntp openbsd-netcat open-iscsi python-pexpect qemu rsync screen \
+        socat squashfs-tools strace time tpm2-tools swtpm vi wireguard-tools
 
     # Unlock root account and set its password to 'vagrant' to allow root login
     # via ssh


### PR DESCRIPTION
which are required for the NFS share to work correctly.