### PR TITLE
tree-wide: save only meson's text artifacts

### DIFF
--- a/agent/testsuite-alt.sh
+++ b/agent/testsuite-alt.sh
@@ -13,7 +13,6 @@ LIB_ROOT="$(dirname "$0")/../common"
 at_exit() {
     set +e
     exectask "journalctl-testsuite" "journalctl -b --no-pager"
-    [[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 }
 
 trap at_exit EXIT
@@ -59,6 +58,7 @@ echo 'int main(void) { return 77; }' > src/test/test-execute.c
 sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test/test-network/systemd-networkd-tests.py
 exectask "ninja-test_sanitizers_$(uname -m)" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"
+[[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"
 
 # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
 export QEMU_TIMEOUT=1200

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -81,7 +81,7 @@ echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 # Copy over meson test artifacts
-[[ -d "build/meson-logs" ]] && rsync -aq "build/meson-logs" "$LOGDIR"
+[[ -d "build/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "build/meson-logs" "$LOGDIR"
 
 ## Integration test suite ##
 SKIP_LIST=(

--- a/agent/testsuite-rhel9-sanitizers.sh
+++ b/agent/testsuite-rhel9-sanitizers.sh
@@ -104,7 +104,7 @@ echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3 ${MESON_NUM_PROCESSES:+--num-processes "$MESON_NUM_PROCESSES"}"
 exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"
 # Copy over meson test artifacts
-[[ -d "$BUILD_DIR/meson-logs" ]] && rsync -aq "$BUILD_DIR/meson-logs" "$LOGDIR"
+[[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"
 
 ## Generate a custom-tailored initrd for the integration tests
 # The host initrd contains multipath modules & services which are unused

--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -92,7 +92,7 @@ echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]] && MESON_NUM_PROCESSES=4
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3 ${MESON_NUM_PROCESSES:+--num-processes "$MESON_NUM_PROCESSES"}"
 # Copy over meson test artifacts
-[[ -d "build/meson-logs" ]] && rsync -aq "build/meson-logs" "$LOGDIR"
+[[ -d "build/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "build/meson-logs" "$LOGDIR"
 
 # If we're not testing the main branch (the first diff) check if the tested
 # branch doesn't contain only man-related changes. If so, skip the integration

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -63,7 +63,7 @@ echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]] && MESON_NUM_PROCESSES=4
 exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3 ${MESON_NUM_PROCESSES:+--num-processes "$MESON_NUM_PROCESSES"}"
 # Copy over meson test artifacts
-[[ -d "build/meson-logs" ]] && rsync -aq "build/meson-logs" "$LOGDIR"
+[[ -d "build/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "build/meson-logs" "$LOGDIR"
 
 # If we're not testing the main branch (the first diff) check if the tested
 # branch doesn't contain only man-related changes. If so, skip the integration

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -47,6 +47,7 @@ sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test
 
 exectask "ninja-test" "GCOV_ERROR_FILE=$LOGDIR/ninja-test-gcov-errors.log meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "ninja-test-collect-coverage" "lcov_collect $COVERAGE_DIR/unit-tests.coverage-info $BUILD_DIR && lcov_clear_metadata $BUILD_DIR"
+[[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"
 
 ## Integration test suite ##
 # Prepare a custom-tailored initrd image (with the systemd module included).
@@ -225,7 +226,6 @@ exectask "check_for_missing_coverage" "_check_for_missing_coverage"
 # Summary
 show_task_summary
 
-[[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
 [[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -45,6 +45,7 @@ sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test
 # Run the internal unit tests (make check)
 exectask "ninja-test_sanitizers" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"
+[[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"
 
 ## Run TEST-01-BASIC under sanitizers
 # Prepare a custom-tailored initrd image (with the systemd module included).
@@ -223,7 +224,6 @@ exectask "coredumpctl_collect" "coredumpctl_collect"
 # Summary
 show_task_summary
 
-[[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
 [[ $FAILED -eq 0 ]] && exit 0 || exit 1

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -41,6 +41,7 @@ sed -i '/def test_macsec/i\    @unittest.skip("See systemd/systemd#16199")' test
 
 # Run the internal unit tests (make check)
 exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
+[[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"
 
 ## Integration test suite ##
 # Prepare a custom-tailored initrd image (with the systemd module included).
@@ -186,7 +187,6 @@ exectask "coredumpctl_collect" "coredumpctl_collect"
 # Summary
 show_task_summary
 
-[[ -d "$BUILD_DIR/meson-logs" ]] && cp -r "$BUILD_DIR/meson-logs" "$LOGDIR"
 exectask "journalctl-testsuite" "journalctl -b --no-pager"
 
 [[ $FAILED -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
meson also generates xml and json files which we don't need for possible
debugging. Omitting these files saves ~16M per job.