### PR TITLE
agent(upstream): use standard QEMU on ppc64le nodes

### DIFF
--- a/agent/testsuite-alt.sh
+++ b/agent/testsuite-alt.sh
@@ -28,9 +28,9 @@ if ! coredumpctl_init; then
     exit 1
 fi
 
-if [[ ! -f /usr/bin/ninja ]]; then
-    ln -s /usr/bin/ninja-build /usr/bin/ninja
-fi
+[[ ! -f /usr/bin/ninja ]] && ln -s /usr/bin/ninja-build /usr/bin/ninja
+[[ ! -f /usr/bin/qemu-kvm ]] && ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-kvm
+qemu-kvm --version
 
 set +e
 

--- a/agent/testsuite-alt.sh
+++ b/agent/testsuite-alt.sh
@@ -67,6 +67,9 @@ export NSPAWN_TIMEOUT=1200
 export QEMU_SMP=$(nproc)
 export SKIP_INITRD=no
 export QEMU_BIN=/usr/bin/qemu-kvm
+# Since QEMU without accel is extremely slow on the alt-arch machines, let's use
+# it only when we don't have a choice (i.e. with QEMU-only test)
+export TEST_PREFER_NSPAWN=yes
 
 ## Generate a custom-tailored initrd for the integration tests
 # The host initrd contains multipath modules & services which are unused

--- a/agent/testsuite-alt.sh
+++ b/agent/testsuite-alt.sh
@@ -131,7 +131,9 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         test/TEST-34-DYNAMICUSERMIGRATE
         test/TEST-45-TIMEDATE       # systemd-timedated
         test/TEST-46-HOMED          # systemd-homed
-        test/TEST-50-DISSECT        # systemd-dissect
+        # FIXME: device-mapper complains about invalid ioctl and then dies
+        #        because it can't allocate memory; needs further investigation
+        #test/TEST-50-DISSECT        # systemd-dissect
         test/TEST-54-CREDS          # credentials & stuff
         test/TEST-55-OOMD           # systemd-oomd
         test/TEST-58-REPART         # systemd-repart

--- a/agent/testsuite-alt.sh
+++ b/agent/testsuite-alt.sh
@@ -120,7 +120,9 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
     EXECUTED_LIST=()
     INTEGRATION_TESTS=(
         test/TEST-04-JOURNAL        # systemd-journald
-        test/TEST-13-NSPAWN-SMOKE   # systemd-nspawn
+        # FIXME: This test gets stuck on C8S when calling `sysctl, possibly
+        #        related to https://bugzilla.redhat.com/show_bug.cgi?id=2098125
+        #test/TEST-13-NSPAWN-SMOKE   # systemd-nspawn
         test/TEST-15-DROPIN         # dropin logic
         test/TEST-17-UDEV           # systemd-udevd
         test/TEST-22-TMPFILES       # systemd-tmpfiles


### PR DESCRIPTION
since the alt-arch nodes in CentOS CI don't support nested KVM (yet).