### PR TITLE
agent(upstream): ensure the default kernel is the latest one

### DIFF
--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -257,6 +257,8 @@ GRUBBY_ARGS=(
     # Reboot the machine on kernel panic
     "panic=3"
 )
+# Make sure the latest kernel is the one we're going to boot into
+grubby --set-default "/boot/vmlinuz-$(rpm -q kernel --qf "%{EVR}.%{ARCH}\n" | sort -Vr | head -n1)"
 grubby --args="${GRUBBY_ARGS[*]}" --update-kernel="$(grubby --default-kernel)"
 # Check if the $GRUBBY_ARGS were applied correctly
 for arg in "${GRUBBY_ARGS[@]}"; do


### PR DESCRIPTION
In certain cases some external modules might pull in older kernel
versions, which then set themselves as the default, which causes some
unexpected issues after reboot.