### PR TITLE
agent(upstream-alt): install specific kernel-tools version

### DIFF
--- a/agent/bootstrap-alt.sh
+++ b/agent/bootstrap-alt.sh
@@ -63,7 +63,9 @@ ADDITIONAL_DEPS=(
     integritysetup
     iproute-tc
     iscsi-initiator-utils
-    kernel-modules-extra
+    "kernel-modules-$(uname -r)"
+    "kernel-modules-extra-$(uname -r)"
+    "kernel-tools-$(uname -r)"
     kmod-wireguard # Kmods SIG
     knot
     libasan


### PR DESCRIPTION
Since we're not rebooting the machine in the alt-arch runs, install
kernel-tools and other kernel packages for the currently running kernel
instead of the latest one.