### PR TITLE
vagrant: mount /var/tmp as tmpfs

### DIFF
--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -29,6 +29,10 @@ fi
 # Disable swap, since it seems to cause CPU soft lock-ups in some cases
 swapoff -av
 
+# Mount /var/tmp as tmpfs, since we should have enough memory to run all integration
+# tests in-memory
+mount -v -t tmpfs tmpfs /var/tmp
+
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
 ## FIXME: systemd-networkd testsuite: skip test_macsec


### PR DESCRIPTION
since we should have plenty of spare memory (~180 GB in the VM), let's
run all integration tests in a tmpfs.