### PR TITLE
agent(alt): install systemd-timesync

### DIFF
--- a/agent/bootstrap-alt.sh
+++ b/agent/bootstrap-alt.sh
@@ -93,6 +93,7 @@ ADDITIONAL_DEPS=(
     squashfs-tools
     strace
     systemd-networkd # EPEL
+    systemd-timesyncd # EPEL
     swtpm
     time
     tpm2-tools


### PR DESCRIPTION
to make the systemd-networkd test suite happy.

Since we don't install the built revision, let's install the timesync
package as well, which provides the necessary units, users, and other
configuration.