### PR TITLE
agent-control: don't use a user session for the transient unit

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -346,7 +346,7 @@ def main():
         # for the user sessions.
         # See: https://pagure.io/centos-infra/issue/865#comment-810347
         logging.info("Wait until the machine is fully initialized")
-        ac.execute_remote_command("systemd-run --user --wait -t -p Wants=cloud-init.target -p After=cloud-init.target systemctl --user daemon-reexec")
+        ac.execute_remote_command("systemd-run --wait -t -p Wants=cloud-init.target -p After=cloud-init.target true && systemctl --user daemon-reexec")
 
         # Let's differentiate between CentOS <= 7 (yum) and CentOS >= 8 (dnf)
         pkg_man = "yum" if "centos-7-" in args.pool else "dnf"


### PR DESCRIPTION
Because the cloud-init.target doesn't exist in the user scope, hence the
dependency requirement is a no-op.