### PR TITLE
common: shorten the sleep before checking a process

### DIFF
--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -68,10 +68,10 @@ waitforpid() {
 
     echo "Waiting for PID $pid to finish"
     while kill -0 "$pid" 2>/dev/null; do
-        if ((SECONDS % 10 == 0)); then
+        if ((SECONDS % 100 == 0)); then
             echo -n "."
         fi
-        sleep 1
+        sleep .1
     done
 
     wait "$pid"


### PR DESCRIPTION
This should speed up especially the coredump/sanitizer checks, as they
take < 1s and we run dozens of them in a sequence.