### PR TITLE
vagrant(arch): get more info about soft lockups if/when they happen

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -125,6 +125,7 @@ for t in test/TEST-??-*; do
     fi
 
     ## Configure test environment
+    export KERNEL_APPEND="user_namespace.enable=1 enforcing=0 softlockup_panic=1 softlockup_all_cpu_backtrace=1 panic=1"
     # Tell the test framework to copy the base image for each test, so we
     # can run them in parallel
     export TEST_PARALLELIZE=1
@@ -133,7 +134,6 @@ for t in test/TEST-??-*; do
     export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
     # Explicitly enable user namespaces and default SELinux to permissive
     # for TEST-06-SELINUX (since we use CentOS 8 policy with the upstream systemd)
-    export KERNEL_APPEND="user_namespace.enable=1 enforcing=0"
     # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
     export QEMU_TIMEOUT=600
     export NSPAWN_TIMEOUT=600

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -144,6 +144,7 @@ for t in test/TEST-??-*; do
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
+    export QEMU_OPTIONS="-device i6300esb -watchdog-action poweroff"
 
     # Skipped test don't create the $TESTDIR automatically, so do it explicitly
     # otherwise the `touch` command would fail

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -70,6 +70,7 @@ export SKIP_INITRD=no
 export TEST_NESTED_KVM=yes
 # Bump the SUT memory to 4G, mainly for dfuzzer
 export QEMU_MEM=4G
+export KERNEL_APPEND="softlockup_panic=1 softlockup_all_cpu_backtrace=1 panic=1"
 
 # Enable systemd-coredump
 if ! coredumpctl_init; then
@@ -156,14 +157,6 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
 
         # Set the test dir to something predictable so we can refer to it later
         export TESTDIR="/var/tmp/systemd-test-${t##*/}"
-
-        # Disable nested KVM for TEST-13-NSPAWN-SMOKE, which keeps randomly
-        # failing due to time outs caused by CPU soft locks. Also, bump the
-        # QEMU timeout, since the test is much slower without KVM.
-        export TEST_NESTED_KVM=yes
-        if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
-            unset TEST_NESTED_KVM
-        fi
 
         # Suffix the $TESTDIR of each retry with an index to tell them apart
         export MANGLE_TESTDIR=1

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -71,6 +71,7 @@ export TEST_NESTED_KVM=yes
 # Bump the SUT memory to 4G, mainly for dfuzzer
 export QEMU_MEM=4G
 export KERNEL_APPEND="softlockup_panic=1 softlockup_all_cpu_backtrace=1 panic=1"
+export QEMU_OPTIONS="-device i6300esb -watchdog-action poweroff"
 
 # Enable systemd-coredump
 if ! coredumpctl_init; then

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -116,6 +116,7 @@ for t in test/TEST-??-*; do
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
+    export QEMU_OPTIONS="-device i6300esb -watchdog-action poweroff"
 
     # Skipped test don't create the $TESTDIR automatically, so do it explicitly
     # otherwise the `touch` command would fail

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -102,6 +102,7 @@ for t in test/TEST-??-*; do
     fi
 
     ## Configure test environment
+    export KERNEL_APPEND="softlockup_panic=1 softlockup_all_cpu_backtrace=1 panic=1"
     # Tell the test framework to copy the base image for each test, so we
     # can run them in parallel
     export TEST_PARALLELIZE=1
@@ -115,15 +116,6 @@ for t in test/TEST-??-*; do
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
-
-    # Disable nested KVM for TEST-13-NSPAWN-SMOKE, which keeps randomly
-    # failing due to time outs caused by CPU soft locks. Also, bump the
-    # QEMU timeout, since the test is a bit slower without KVM.
-    export TEST_NESTED_KVM=1
-    if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
-        unset TEST_NESTED_KVM
-        export QEMU_TIMEOUT=1200
-    fi
 
     # Skipped test don't create the $TESTDIR automatically, so do it explicitly
     # otherwise the `touch` command would fail


### PR DESCRIPTION
Let's gather possibly useful information about CPU soft lockups
occasionally triggered by TEST-13-NSPAWN-SMOKE. Since they happen even
without nested KVM, enable nested KVM unconditionally, but trigger a
kernel panic on CPU soft lockups, which should dump more information
about it, and follow it by reboot-on-panic logic to not waste CI time in
a stuck test.
