### PR TITLE
Revert "vagrant(upstream): temporarily skip TEST-29 under sanitizers"

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -122,7 +122,7 @@ done
 #
 # Explicitly enable user namespaces and default SELinux to permissive
 # for TEST-06-SELINUX (since we use CentOS 8 policy with the upstream systemd)
-export KERNEL_APPEND="user_namespace.enable=1 enforcing=0 oops=panic nmi_watchdog=1 softlockup_panic=1 softlockup_all_cpu_backtrace=1 panic=1"
+export KERNEL_APPEND="user_namespace.enable=1 enforcing=0"
 # Explicitly set paths to initramfs and kernel images (for QEMU tests)
 # See $INITRD above
 export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -158,15 +158,6 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
             continue
         fi
 
-        # Disable nested KVM for TEST-13-NSPAWN-SMOKE, which keeps randomly
-        # failing due to time outs caused by CPU soft locks. Also, bump the
-        # QEMU timeout, since the test is a bit slower without KVM.
-        export TEST_NESTED_KVM=1
-        if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
-            unset TEST_NESTED_KVM
-            export QEMU_TIMEOUT=1200
-        fi
-
         # Set the test dir to something predictable so we can refer to it later
         export TESTDIR="/var/tmp/systemd-test-${t##*/}"
 

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -70,7 +70,6 @@ export SKIP_INITRD=no
 export TEST_NESTED_KVM=1
 # Bump the SUT memory to 4G, mainly for dfuzzer
 export QEMU_MEM=4G
-export KERNEL_APPEND="kernel.nmi_watchdog=1 kernel.softlockup_panic=1 kernel.softlockup_all_cpu_backtrace=1 panic=1 oops=panic"
 # Don't strip systemd binaries installed into test images, so we can get nice
 # stack traces when something crashes
 export STRIP_BINARIES=no

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -134,8 +134,7 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         test/TEST-21-DFUZZER        # fuzz all systemd D-Bus interfaces
         test/TEST-22-TMPFILES       # systemd-tmpfiles
         test/TEST-23-TYPE-EXEC
-        # Skip TEST-29 until systemd/systemd#24147 is resolved
-        #test/TEST-29-PORTABLE       # systemd-portabled
+        test/TEST-29-PORTABLE       # systemd-portabled
         test/TEST-34-DYNAMICUSERMIGRATE
         test/TEST-45-TIMEDATE       # systemd-timedated
         test/TEST-46-HOMED          # systemd-homed

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -97,7 +97,6 @@ done
 
 # Shared test env variables
 #
-export KERNEL_APPEND="kernel.nmi_watchdog=1 kernel.softlockup_panic=1 kernel.softlockup_all_cpu_backtrace=1 panic=1 oops=panic"
 # Set timeouts for QEMU and nspawn tests to kill them in case they get stuck
 export QEMU_TIMEOUT=900
 export NSPAWN_TIMEOUT=900

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -125,16 +125,6 @@ for t in test/TEST-??-*; do
     # Use a "unique" name for each nspawn container to prevent scope clash
     export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
-    # Disable nested KVM for TEST-13-NSPAWN-SMOKE, which keeps randomly
-    # failing due to time outs caused by CPU soft locks. Also, bump the
-    # QEMU timeout, since the test is a bit slower without KVM.
-    export TEST_NESTED_KVM=1
-    export QEMU_TIMEOUT=900
-    if [[ "$t" == "test/TEST-13-NSPAWN-SMOKE" ]]; then
-        unset TEST_NESTED_KVM
-        export QEMU_TIMEOUT=1200
-    fi
-
     # Skipped test don't create the $TESTDIR automatically, so do it explicitly
     # otherwise the `touch` command would fail
     mkdir -p "$TESTDIR"


### PR DESCRIPTION
This reverts commit dba929fdc2781fe98d4fce10c94d051d6fca4770.