### PR TITLE
tree-wide: s/artifacts.ci.aws.centos.org/artifacts.ci.centos.org/g

### DIFF
--- a/utils/artifacts-copy-file.sh
+++ b/utils/artifacts-copy-file.sh
@@ -20,9 +20,9 @@ mkdir -p "$SRC_DIR" "$DEST_DIR"
 # Crucial line, otherwise we won't be able to access the web directory listing
 chmod -R o+rx .
 
-rsync -av "systemd@artifacts.ci.aws.centos.org:/srv/artifacts/systemd/$SRC" "$SRC_DIR"
+rsync -av "systemd@artifacts.ci.centos.org:/srv/artifacts/systemd/$SRC" "$SRC_DIR"
 mv -v "$SRC" "$DEST"
 rm -fr "$SRC"
-rsync -av . "systemd@artifacts.ci.aws.centos.org:/srv/artifacts/systemd/"
+rsync -av . "systemd@artifacts.ci.centos.org:/srv/artifacts/systemd/"
 
 popd

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -138,7 +138,7 @@ vagrant package --no-tty --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/"
 mkdir vagrant_boxes
 mv "$BOX_NAME" vagrant_boxes
 
-rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $DUFFY_SSH_KEY" -av "vagrant_boxes" systemd@artifacts.ci.aws.centos.org:/srv/artifacts/systemd/
-echo "Box URL: https://artifacts.ci.aws.centos.org/systemd/vagrant_boxes/$BOX_NAME"
+rsync -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $DUFFY_SSH_KEY" -av "vagrant_boxes" systemd@artifacts.ci.centos.org:/srv/artifacts/systemd/
+echo "Box URL: https://artifacts.ci.centos.org/systemd/vagrant_boxes/$BOX_NAME"
 
 exit $EC

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -9,12 +9,11 @@ Vagrant.configure("2") do |config|
   # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
   if ENV["VAGRANT_TEST_IMAGE"] then
     config.vm.box = "archlinux_systemd-new"
-    config.vm.box_url = "https://artifacts.ci.aws.centos.org/systemd/vagrant_boxes/archlinux_systemd-new"
+    config.vm.box_url = "https://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd-new"
   else
     config.vm.box = "archlinux_systemd"
-    config.vm.box_url = "https://artifacts.ci.aws.centos.org/systemd/vagrant_boxes/archlinux_systemd"
+    config.vm.box_url = "https://artifacts.ci.centos.org/systemd/vagrant_boxes/archlinux_systemd"
   end
-  config.vm.box_download_insecure = true
 
   # Disable the default /vagrant share, since we don't use it anyway
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrant/vagrantfiles/Vagrantfile_rawhide
+++ b/vagrant/vagrantfiles/Vagrantfile_rawhide
@@ -9,12 +9,11 @@ Vagrant.configure("2") do |config|
   # Use our updated & cached Vagrant box (see vagrant/vagrant-make-cache.sh)
   if ENV["VAGRANT_TEST_IMAGE"] then
     config.vm.box = "rawhide_selinux-new"
-    config.vm.box_url = "https://artifacts.ci.aws.centos.org/systemd/vagrant_boxes/rawhide_selinux-new"
+    config.vm.box_url = "https://artifacts.ci.centos.org/systemd/vagrant_boxes/rawhide_selinux-new"
   else
     config.vm.box = "rawhide_selinux"
-    config.vm.box_url = "http://artifacts.ci.aws.centos.org/systemd/vagrant_boxes/rawhide_selinux"
+    config.vm.box_url = "https://artifacts.ci.centos.org/systemd/vagrant_boxes/rawhide_selinux"
   end
-  config.vm.box_download_insecure = true
 
   # Disable the default /vagrant share, since we don't use it anyway
   config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
The legacy artifact box migration is complete, so let's use the old
artifact box URL again, which also has a valid TLS cert.