### PR TITLE
vagrant: make the setup stuff a bit more robust

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -25,6 +25,6 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v2
+        uses: redhat-plumbers-in-action/differential-shellcheck@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should help with intermittent `vagrant plugin install` errors:

```
Installing the 'vagrant-libvirt' plugin. This can take a few minutes...
Vagrant failed to load a configured plugin source. This can be caused
by a variety of issues including: transient connectivity issues, proxy
filtering rejecting access to a configured plugin source, or a
configured
plugin source not responding correctly. Please review the error message
below to help resolve the issue:

  timed out (https://rubygems.org/specs.4.8.gz)

  Source: https://rubygems.org/
```