### PR TITLE
vagrant(arch): run TEST-64-UDEV-STORAGE with sanitizers

### DIFF
--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -141,6 +141,7 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
         test/TEST-54-CREDS          # credentials & stuff
         test/TEST-55-OOMD           # systemd-oomd
         test/TEST-58-REPART         # systemd-repart
+        test/TEST-64-UDEV-STORAGE   # systemd-udevd with various storage setups
         test/TEST-65-ANALYZE        # systemd-analyze
         test/TEST-70-TPM2           # systemd-cryptenroll
         test/TEST-71-HOSTNAME       # systemd-hostnamed


### PR DESCRIPTION
With the latest tweaks it appears to be stable under ASan and the runtime seems to be reasonable as well:

OK (2m)   testcase_megasas2_basic()
OK (45s)  testcase_nvme_basic()
OK (45s)  testcase_virtio_scsi_identically_named_partitions()
OK (2m)   testcase_multipath_basic_failover()
OK (1m)   testcase_simultaneous_events()
OK (3m)   testcase_lvm_basic()
OK (2m)   testcase_btrfs_basic()
OK (2m)   testcase_iscsi_lvm()
OK (1m)   testcase_long_sysfs_path()
OK (2m)   testcase_mdadm_basic()
OK (1m)   testcase_mdadm_lvm()