### PR TITLE
tree-wide: drop all seamicro-related workarounds

### DIFF
--- a/agent/testsuite-rhel9-sanitizers.sh
+++ b/agent/testsuite-rhel9-sanitizers.sh
@@ -96,12 +96,7 @@ echo 'int main(void) { return 77; }' > src/test/test-seccomp.c
 echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 
 # Run the internal unit tests (make check)
-# Note: All .dusty.* servers have Intel Xeon CPUs with 4 cores and HT enabled
-#       which causes issues when the machine is under heavy load (in this case
-#       when meson parallelizes the jobs on all 8 CPUs) - namely spurious
-#       timeouts and hangups/deadlocks (like in test-barries).
-[[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]] && MESON_NUM_PROCESSES=4
-exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3 ${MESON_NUM_PROCESSES:+--num-processes "$MESON_NUM_PROCESSES"}"
+exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-multiplier=3"
 exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/testlog*.txt | check_for_sanitizer_errors"
 # Copy over meson test artifacts
 [[ -d "$BUILD_DIR/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "$BUILD_DIR/meson-logs" "$LOGDIR"

--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -85,12 +85,7 @@ echo 'int main(void) { return 77; }' > src/test/test-seccomp.c
 echo 'int main(void) { return 77; }' > src/test/test-barrier.c
 
 # Run the internal unit tests (make check)
-# Note: All .dusty.* servers have Intel Xeon CPUs with 4 cores and HT enabled
-#       which causes issues when the machine is under heavy load (in this case
-#       when meson parallelizes the jobs on all 8 CPUs) - namely spurious
-#       timeouts and hangups/deadlocks (like in test-barries).
-[[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]] && MESON_NUM_PROCESSES=4
-exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3 ${MESON_NUM_PROCESSES:+--num-processes "$MESON_NUM_PROCESSES"}"
+exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 # Copy over meson test artifacts
 [[ -d "build/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "build/meson-logs" "$LOGDIR"
 

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -37,12 +37,7 @@ set +e
 pushd systemd || { echo >&2 "Can't pushd to systemd"; exit 1; }
 
 # Run the internal unit tests (make check)
-# Note: All .dusty.* servers have Intel Xeon CPUs with 4 cores and HT enabled
-#       which causes issues when the machine is under heavy load (in this case
-#       when meson parallelizes the jobs on all 8 CPUs) - namely spurious
-#       timeouts and hangups/deadlocks (like in test-barries).
-[[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]] && MESON_NUM_PROCESSES=4
-exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3 ${MESON_NUM_PROCESSES:+--num-processes "$MESON_NUM_PROCESSES"}"
+exectask "ninja-test" "meson test -C build --print-errorlogs --timeout-multiplier=3"
 # Copy over meson test artifacts
 [[ -d "build/meson-logs" ]] && rsync -amq --include '*.txt' --include '*/' --exclude '*' "build/meson-logs" "$LOGDIR"
 

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -50,16 +50,6 @@ else
     OPTIMAL_QEMU_SMP=${OPTIMAL_QEMU_SMP:-1}
 fi
 
-if ! systemd-detect-virt -vq && [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]]; then
-    # All dusty machines have Intel Xeon CPUs with 4 cores and HT enabled,
-    # which causes issues when the HT cores are counted as "real" ones, namely
-    # CPU over-saturation and strange hangups. As all dusty server have the
-    # same HW, let's manually override the # of CPUs for the VM to 4.
-    _log "Running on a *.dusty machine, overriding the # of CPUs to 4 and queue size to 1"
-    MAX_QUEUE_SIZE=1
-    OPTIMAL_QEMU_SMP=4
-fi
-
 echo "[TASK-CONTROL] OPTIMAL_QEMU_SMP = $OPTIMAL_QEMU_SMP"
 echo "[TASK-CONTROL] MAX_QUEUE_SIZE = $MAX_QUEUE_SIZE"
 

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -74,8 +74,7 @@ SKIP_LIST=(
 ## Other integration tests ##
 # Enqueue the "other" tests first. The networkd testsuite has quite a long
 # runtime without requiring too much resources, hence it can run in parallel
-# with the "standard" integration tests, saving ~30 minutes ATTOW (this excludes
-# dusty nodes, where any kind of parallelism leads to unstable tests)
+# with the "standard" integration tests, saving ~30 minutes ATTOW
 TEST_LIST=(
     "test/test-exec-deserialization.py"
     "test/test-network/systemd-networkd-tests.py"

--- a/vagrant/vagrant-build.sh
+++ b/vagrant/vagrant-build.sh
@@ -87,15 +87,7 @@ fi
 export SYSTEMD_ROOT="${SYSTEMD_ROOT:-$HOME/systemd}"
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
 export VAGRANT_MEMORY="${VAGRANT_MEMORY:-184320}"
-if [[ "$(hostnamectl --static)" =~ .dusty.ci.centos.org$ ]]; then
-    # All dusty machines have Intel Xeon CPUs with 4 cores and HT enabled,
-    # which causes issues when the HT cores are counted as "real" ones, namely
-    # CPU over-saturation and strange hangups. As all dusty server have the
-    # same HW, let's manually override the # of CPUs for the VM to 4.
-    export VAGRANT_CPUS=4
-else
-    export VAGRANT_CPUS="${VAGRANT_CPUS:-$(nproc)}"
-fi
+export VAGRANT_CPUS="${VAGRANT_CPUS:-$(nproc)}"
 export VAGRANT_BOOTSTRAP_SCRIPT="$BOOTSTRAP_SCRIPT"
 
 # Absolute systemd git root path on the host machine


### PR DESCRIPTION
since all jobs were migrated to AWS and the seamicro chassis are going to disappear soon.