### PR TITLE
agent(c8s): remove the test images unconditionally

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -139,7 +139,7 @@ for t in test/TEST-??-*; do
     #        to work around intermittent QEMU soft lockups/ACPI timer errors
     #
     # Suffix the $TESTDIR of each retry with an index to tell them apart
-    exectask_retry_p "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass && rm -fv \$TESTDIR/*.img" "${TASK_RETRIES:?}"
+    exectask_retry_p "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass; rm -fv \$TESTDIR/*.img; test -e \$TESTDIR/pass" "${TASK_RETRIES:?}"
     # Retried tasks are suffixed with an index, so update the $CHECK_LIST
     # array with all possible task names correctly find the respective journals
     # shellcheck disable=SC2207

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -142,7 +142,7 @@ for t in "${INTEGRATION_TESTS[@]}"; do
     #
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1
-    exectask_retry_p "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass && rm -fv \$TESTDIR/*.img" "${TASK_RETRIES:?}"
+    exectask_retry_p "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass; rm -fv \$TESTDIR/*.img; test -e \$TESTDIR/pass" "${TASK_RETRIES:?}"
     # Retried tasks are suffixed with an index, so update the $CHECK_LIST
     # array with all possible task names correctly find the respective journals
     # shellcheck disable=SC2207
@@ -164,7 +164,7 @@ for t in "${FLAKE_LIST[@]}"; do
 
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1
-    exectask_retry "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass && rm -fv \$TESTDIR/*.img"
+    exectask_retry "${t##*/}" "/bin/time -v -- make -C $t setup run && touch \$TESTDIR/pass; rm -fv \$TESTDIR/*.img; test -e \$TESTDIR/pass"
 
     # Retried tasks are suffixed with an index, so update the $CHECK_LIST
     # array accordingly to correctly find the respective journals

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -190,7 +190,7 @@ exectask_retry() {
         echo "[TASK START] $(date)" >>"$logfile"
 
         # Suffix the $TESTDIR for each retry by its index if requested
-        if [[ -v MANGLE_TESTDIR && "$MANGLE_TESTDIR" -ne 0 ]]; then
+        if [[ "${MANGLE_TESTDIR:-0}" -ne 0 ]]; then
             orig_testdir="${orig_testdir:-$TESTDIR}"
             export TESTDIR="${orig_testdir}_${i}"
             mkdir -p "$TESTDIR"


### PR DESCRIPTION
Otherwise they might accumulate from the retried tasks and cause
unexpected fails, as the storage on the EC2 machines is quite small.