### PR TITLE
common: mangle nspawn container name as well if necessary

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -124,9 +124,6 @@ for t in test/TEST-??-*; do
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
     export QEMU_OPTIONS="-cpu max"
 
-    rm -fr "$TESTDIR"
-    mkdir -p "$TESTDIR"
-
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1
     # FIXME: retry each task again if it fails (i.e. run each task twice at most)

--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -123,8 +123,6 @@ for t in test/TEST-??-*; do
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
     export QEMU_OPTIONS="-cpu max"
-    # Use a "unique" name for each nspawn container to prevent scope clash
-    export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
     rm -fr "$TESTDIR"
     mkdir -p "$TESTDIR"

--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -206,8 +206,6 @@ for t in "${FLAKE_LIST[@]}"; do
     # Set QEMU_SMP appropriately (regarding the parallelism)
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$(nproc)
-    # Use a "unique" name for each nspawn container to prevent scope clash
-    export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -126,11 +126,6 @@ for t in "${INTEGRATION_TESTS[@]}"; do
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
 
-    # Skipped test don't create the $TESTDIR automatically, so do it explicitly
-    # otherwise the `touch` command would fail
-    mkdir -p "$TESTDIR"
-    rm -f "$TESTDIR/pass"
-
     # FIXME: retry each task again if it fails (i.e. run each task twice at most)
     #        to work around intermittent QEMU soft lockups/ACPI timer errors
     #

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -125,8 +125,6 @@ for t in "${INTEGRATION_TESTS[@]}"; do
     # Set QEMU_SMP appropriately (regarding the parallelism)
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$OPTIMAL_QEMU_SMP
-    # Use a "unique" name for each nspawn container to prevent scope clash
-    export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
     # Skipped test don't create the $TESTDIR automatically, so do it explicitly
     # otherwise the `touch` command would fail
@@ -155,8 +153,6 @@ for t in "${FLAKE_LIST[@]}"; do
     # Set QEMU_SMP appropriately (regarding the parallelism)
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$(nproc)
-    # Use a "unique" name for each nspawn container to prevent scope clash
-    export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -308,7 +308,7 @@ exectask_p_finish() {
 
     for key in "${!TASK_QUEUE[@]}"; do
         echo "[INFO] Waiting for task '$key' to finish..."
-        wait ${TASK_QUEUE[$key]}
+        wait "${TASK_QUEUE[$key]}"
         unset "TASK_QUEUE[$key]"
     done
 }

--- a/common/task-control.sh
+++ b/common/task-control.sh
@@ -190,12 +190,19 @@ exectask_retry() {
         echo "[TASK] $task_name ($task_command) [try $i/$retries]"
         echo "[TASK START] $(date)" >>"$logfile"
 
-        # Suffix the $TESTDIR for each retry by its index if requested
+        # Make sure each retry has a unique state dir ($TESTDIR) and container
+        # name (passed in $NSPAWN_ARGUMENTS), so we don't overwrite results
+        # of previous retries or die because of a name clash.
+        # Note: this is relevant only for the integration tests (test/TEST-??-*)
         if [[ "${MANGLE_TESTDIR:-0}" -ne 0 ]]; then
+            # Suffix the $TESTDIR for each retry by its index if requested
             orig_testdir="${orig_testdir:-$TESTDIR}"
             export TESTDIR="${orig_testdir}_${i}"
             mkdir -p "$TESTDIR"
             rm -f "$TESTDIR/pass"
+
+            # Also, set a unique name for each nspawn container to prevent scope clash
+            export NSPAWN_ARGUMENTS="--machine=${task_name}--${i}"
         fi
 
         # shellcheck disable=SC2086

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -121,8 +121,6 @@ for t in "${FLAKE_LIST[@]}"; do
     export QEMU_SMP=$(nproc)
     # Enforce nested KVM
     export TEST_NESTED_KVM=1
-    # Use a "unique" name for each nspawn container to prevent scope clash
-    export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -155,7 +155,6 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
 
         export TEST_PARALLELIZE=1
         export QEMU_SMP=$OPTIMAL_QEMU_SMP
-        export NSPAWN_ARGUMENTS="--machine=${t##*/}"
         # Set the test dir to something predictable so we can refer to it later
         export TESTDIR="/var/tmp/systemd-test-${t##*/}"
 

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -134,8 +134,6 @@ for t in "${FLAKE_LIST[@]}"; do
     # Set QEMU_SMP appropriately (regarding the parallelism)
     # OPTIMAL_QEMU_SMP is part of the common/task-control.sh file
     export QEMU_SMP=$(nproc)
-    # Use a "unique" name for each nspawn container to prevent scope clash
-    export NSPAWN_ARGUMENTS="--machine=${t##*/}"
 
     # Suffix the $TESTDIR of each retry with an index to tell them apart
     export MANGLE_TESTDIR=1


### PR DESCRIPTION
When retrying a task suffix the nspawn container name with the retry ID, so each retry has a unique name, otherwise we might end up with a scope name clash if the container was SIGKILLed (due to a timeout):

```
Spawning container TEST-69-SHUTDOWN on /var/tmp/systemd-test-TEST-69-SHUTDOWN_2/root.
Press Ctrl-] three times within 1s to kill container.
Failed to allocate scope: Unit TEST-69-SHUTDOWN.scope was already loaded or has a fragment file.
```