### PR TITLE
upstream: install fsverity-related utils for TEST-29-PORTABLE

### DIFF
--- a/agent/bootstrap-alt.sh
+++ b/agent/bootstrap-alt.sh
@@ -60,6 +60,7 @@ ADDITIONAL_DEPS=(
     elfutils-devel
     evemu
     expect
+    fsverity-utils # EPEL
     gcc-c++
     glibc-langpack-en
     integritysetup
@@ -69,6 +70,7 @@ ADDITIONAL_DEPS=(
     "kernel-modules-$(uname -r)"
     "kernel-modules-extra-$(uname -r)"
     "kernel-tools-$(uname -r)"
+    keyutils
     kmod-wireguard # Kmods SIG
     knot
     knot-dnssecutils
@@ -110,6 +112,7 @@ ADDITIONAL_DEPS=(
     tpm2-tss-devel
     veritysetup
     wget
+    vim-common
     zstd
 )
 

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -60,6 +60,7 @@ ADDITIONAL_DEPS=(
     elfutils-devel
     evemu
     expect
+    fsverity-utils # EPEL
     gcc-c++
     glibc-langpack-en
     integritysetup
@@ -67,6 +68,7 @@ ADDITIONAL_DEPS=(
     iscsi-initiator-utils
     jq
     kernel-modules-extra
+    keyutils
     kmod-wireguard # Kmods SIG
     knot
     knot-dnssecutils
@@ -107,6 +109,7 @@ ADDITIONAL_DEPS=(
     tpm2-tools
     tpm2-tss-devel
     veritysetup
+    vim-common
     wget
     zstd
 )

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -44,9 +44,9 @@ Vagrant.configure("2") do |config|
     # Note: openbsd-netcat in favor of gnu-netcat is used intentionally, as
     #       the GNU one doesn't support -U option required by test/TEST-12-ISSUE-3171
     pacman --needed --noconfirm -S coreutils bind busybox dhclient dhcp dhcpcd diffutils dnsmasq dosfstools e2fsprogs erofs-utils \
-        evemu expect gdb inetutils jq knot lcov libdwarf libelf mdadm mtools net-tools nfs-utils nftables ntp openbsd-netcat open-iscsi \
-        python-pefile python-pexpect python-psutil python-pyelftools python-pyparsing python-pytest qemu rsync screen socat squashfs-tools \
-        strace time tpm2-tools swtpm vi wireguard-tools
+        evemu expect fsverity-utils gdb inetutils jq knot keyutils lcov libdwarf libelf mdadm mtools net-tools nfs-utils nftables ntp \
+        openbsd-netcat open-iscsi python-pefile python-pexpect python-psutil python-pyelftools python-pyparsing python-pytest qemu rsync \
+        screen socat squashfs-tools strace time tpm2-tools swtpm vim wireguard-tools
 
     # Unlock root account and set its password to 'vagrant' to allow root login
     # via ssh


### PR DESCRIPTION
Introduced in https://github.com/systemd/systemd/pull/26719.