### PR TITLE
agent-control: wait for any potential dnf processes to finish

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -399,7 +399,8 @@ def main():
             # for the user sessions.
             # See: https://pagure.io/centos-infra/issue/865#comment-810347
             logging.info("Wait until the machine is fully initialized")
-            ac.execute_remote_command("systemd-run --wait -p Wants=cloud-init.target -p After=cloud-init.target true && systemctl --user daemon-reexec")
+            dnf_wait = "bash -c 'while pgrep -a dnf; do sleep 1; done'"
+            ac.execute_remote_command(f"systemd-run --wait -p Wants=cloud-init.target -p After=cloud-init.target -- {dnf_wait} && systemctl --user daemon-reexec")
 
         # Let's differentiate between CentOS <= 7 (yum) and CentOS >= 8 (dnf)
         pkg_man = "yum" if "centos-7-" in args.pool else "dnf"

--- a/agent-control.py
+++ b/agent-control.py
@@ -272,7 +272,7 @@ class AgentControl():
             time.sleep(15)
 
         if rc != 0:
-            raise Exception("Timeout reached when waiting for node to become online")
+            raise RuntimeError("Timeout reached when waiting for node to become online")
 
         logging.info("Node %s appears reachable again", self.node)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+duffy[client]>=3.3.5
+httpx


### PR DESCRIPTION
Extend the cloud-init/dnf workaround to also check for any potentially
running dnf processes to finish to avoid clashing with them:

```
2023-03-19 14:17:46,416 [agent-control/execute_local_command] INFO: Executing a LOCAL command: /usr/bin/ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=180 -o TCPKeepAlive=yes -o ServerAliveInterval=30 -l root n27-37-59.pool.ci.centos.org systemd-run --wait -p Wants=cloud-init.target -p After=cloud-init.target true && systemctl --user daemon-reexec
Pseudo-terminal will not be allocated because stdin is not a terminal.
Warning: Permanently added 'n27-37-59.pool.ci.centos.org,172.27.37.59' (ECDSA) to the list of known hosts.
Running as unit: run-u33.service
Finished with result: success
Main processes terminated with: code=exited/status=0
Service runtime: 3ms
2023-03-19 14:17:46,607 [agent-control/main] INFO: PHASE 1: Setting up basic dependencies to configure CI repository
2023-03-19 14:17:46,607 [agent-control/execute_remote_command] INFO: Executing a REMOTE command on node 'n27-37-59.pool.ci.centos.org': dnf clean all && dnf makecache && dnf -y install bash git rsync && rm -fr systemd-centos-ci && git clone https://github.com/systemd/systemd-centos-ci
2023-03-19 14:17:46,607 [agent-control/execute_local_command] INFO: Executing a LOCAL command: /usr/bin/ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=180 -o TCPKeepAlive=yes -o ServerAliveInterval=30 -l root n27-37-59.pool.ci.centos.org dnf clean all && dnf makecache && dnf -y install bash git rsync && rm -fr systemd-centos-ci && git clone https://github.com/systemd/systemd-centos-ci
Pseudo-terminal will not be allocated because stdin is not a terminal.
27 files removed
CentOS Stream 8 - AppStream                      36 MB/s |  29 MB     00:00
CentOS Stream 8 - BaseOS                         33 MB/s |  28 MB     00:00
CentOS Stream 8 - Extras                        287 kB/s |  18 kB     00:00
CentOS Stream 8 - Extras common packages         27 kB/s | 5.3 kB     00:00
Error: Cannot open file "/var/cache/dnf/appstream-47c004699fed5136/repodata/9d4b51d4f519faac1636aecad37f3405d7a6e862a9c6c79b07745e9b77bd6af2-modules.yaml.xz": No such file or directory
```

Not sure why the locking stuff in dnf doesn't work here, but let's see if
this workaround is going to help.