### PR TITLE
agent-control: check if we can ssh after allocating a node

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -93,6 +93,18 @@ class AgentControl():
         assert self.node, "Can't continue without a valid node"
         logging.info("Allocated node %s with session id %s", self.node, self._session_id)
 
+        logging.info("Checking if node %s is reachable over ssh", self.node)
+        reachable = False
+        for _ in range(10):
+            if self.execute_remote_command("true", ignore_rc=True) == 0:
+                reachable = True
+                break
+
+            time.sleep(5)
+
+        if not reachable:
+            raise RuntimeError(f"Node {self.node} doesn't appear to be reachable over ssh")
+
     def execute_local_command(self, command):
         """Execute a command on the local machine
 


### PR DESCRIPTION
Sometimes when we get a fresh machine from the AWS pool we might hit
a transient network issue during the first ssh connection:
```
2023-03-25 13:13:44,522 [agent-control/allocate_node] INFO: Allocated node n27-44-182.pool.ci.centos.org with session id 173151
2023-03-25 13:13:44,523 [agent-control/main] INFO: Wait until the machine is fully initialized
2023-03-25 13:13:44,523 [agent-control/execute_remote_command] INFO: Executing a REMOTE command on node 'n27-44-182.pool.ci.centos.org': ...
2023-03-25 13:13:44,523 [agent-control/execute_local_command] INFO: Executing a LOCAL command: /usr/bin/ssh -t -o ...
Pseudo-terminal will not be allocated because stdin is not a terminal.
ssh: Could not resolve hostname n27-44-182.pool.ci.centos.org: Name or service not known
```
Let's do a test ssh connection just after allocating a node and retry it
a couple of times if needed, to make the CI a bit more resilient in this case.
