### PR TITLE
agent(upstream): prefer nspawn when running tests

### DIFF
--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -103,6 +103,10 @@ export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
 export QEMU_TIMEOUT=1800
 export NSPAWN_TIMEOUT=600
 export QEMU_OPTIONS="-cpu max"
+# Since the situation with overloaded AWS regions got quite unbearable and most
+# of the C8S jobs failed with crapton of timeouts, lets resort to running most
+# of the tests only in nspawn and use qemu only when necessary
+export TEST_PREFER_NSPAWN=yes
 
 # Let's re-shuffle the test list a bit by placing the most expensive tests
 # in the front, so they can run in background while we go through the rest


### PR DESCRIPTION
As the situation with overloaded AWS regions got quite unbearable and most of the C8S jobs keep failing with timeouts, let's resort to running most of the tests in nspawn only and use qemu only when absolutely necessary. This is something that Ubuntu CI already does for quite a long time, so the test sutie is already fine-tuned to use qemu only when we really have to.

We shouldn't lose any coverage (or barely any) as we still run both parts in the Arch Linux job which doesn't suffer from this issue as it runs on a baremetal machine, not a VM.

This issue is, unfortunately, out of my reach, as that's how the machine pool in AWS is configured, see [0].

[0] https://lists.centos.org/pipermail/ci-users/2022-October/004618.html