### PR TITLE
agent: run only nspawn tests in the C8S job on PRs

### DIFF
--- a/agent-control.py
+++ b/agent-control.py
@@ -406,6 +406,8 @@ def main():
             help="Skip reboot between bootstrap and test phases (on baremetal machines)")
     parser.add_argument("--testsuite-script", metavar="SCRIPT", type=str, default="testsuite.sh",
             help="Script which runs tests on the bootstrapped machine")
+    parser.add_argument("--testsuite-args", metavar="ARGUMENTS", type=str, default="",
+            help="Additional optional arguments passed to the --testsuite-script")
     parser.add_argument("--timeout", metavar="MINUTES", type=int, default=0,
             help="Set a timeout for the test run (in minutes)")
     parser.add_argument("--vagrant", metavar="DISTRO_TAG", type=str, default="",
@@ -504,7 +506,7 @@ def main():
                 ac.reboot_node()
 
             logging.info("PHASE 3: Upstream testsuite")
-            command = f"{GITHUB_CI_REPO}/agent/{args.testsuite_script}"
+            command = f"{GITHUB_CI_REPO}/agent/{args.testsuite_script} {args.testsuite_args}"
             ac.execute_remote_command(command, artifacts_dir="~/testsuite-logs*")
 
     except SignalException:

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -18,6 +18,10 @@ set -o pipefail
 
 trap at_exit EXIT
 
+if [[ "${1:-}" == "-n" ]]; then
+    export TEST_NO_QEMU=1
+fi
+
 ### TEST PHASE ###
 # Enable systemd-coredump
 if ! coredumpctl_init; then

--- a/jenkins/runners/upstream-centos8-stable.sh
+++ b/jenkins/runners/upstream-centos8-stable.sh
@@ -56,6 +56,7 @@ git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
 ./agent-control.py --pool virt-ec2-t2-centos-8s-x86_64 \
-                   --bootstrap-args='-s https://github.com/systemd/systemd-stable.git' \
+                   --bootstrap-args="-s https://github.com/systemd/systemd-stable.git" \
+                   --testsuite-args="-n" \
                    --kdump-collect \
                    ${ARGS:+"${ARGS[@]}"}

--- a/jenkins/runners/upstream-centos8.sh
+++ b/jenkins/runners/upstream-centos8.sh
@@ -84,4 +84,7 @@ fi
 git clone https://github.com/systemd/systemd-centos-ci
 cd systemd-centos-ci
 
-./agent-control.py --timeout 180 --pool virt-ec2-t2-centos-8s-x86_64 --kdump-collect ${ARGS:+"${ARGS[@]}"}
+./agent-control.py --pool virt-ec2-t2-centos-8s-x86_64 \
+                   --testsuite-args="-n" \
+                   --kdump-collect \
+                   ${ARGS:+"${ARGS[@]}"}


### PR DESCRIPTION
Since the issues with overloaded AWS regions are still there and are unlikely to disappear in a foreseeable future, let's give up on the QEMU stuff and run only tests that run in nspawn. We'll lose some coverage on C8S (mainly from TEST-64), but it's still better than not running anything.

To make up for this, I'll set up a cron job that'll run the whole test suite at least once a day in the "non-busy" hours.