### PR TITLE
Forward logs to console only in initrd during boot check

### DIFF
--- a/agent/bootstrap-rhel8.sh
+++ b/agent/bootstrap-rhel8.sh
@@ -236,7 +236,7 @@ fi
     # (for QEMU tests)
     export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
     # Enable kernel debug output for easier debugging when something goes south
-    export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console $CGROUP_KERNEL_ARGS"
+    export KERNEL_APPEND="debug systemd.log_level=debug rd.systemd.log_target=console $CGROUP_KERNEL_ARGS"
     # Set timeout for QEMU tests to kill them in case they get stuck
     export QEMU_TIMEOUT=600
     # Disable nspawn version of the test

--- a/agent/bootstrap-rhel9.sh
+++ b/agent/bootstrap-rhel9.sh
@@ -318,7 +318,7 @@ fi
     # (for QEMU tests)
     export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
     # Enable kernel debug output for easier debugging when something goes south
-    export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console systemd.default_standard_output=journal+console ${CGROUP_KERNEL_ARGS[*]}"
+    export KERNEL_APPEND="debug systemd.log_level=debug rd.systemd.log_target=console systemd.default_standard_output=journal+console ${CGROUP_KERNEL_ARGS[*]}"
     # Set timeout for QEMU tests to kill them in case they get stuck
     export QEMU_TIMEOUT=600
     # Disable nspawn version of the test

--- a/agent/bootstrap.sh
+++ b/agent/bootstrap.sh
@@ -235,7 +235,7 @@ DRACUT_OPTS=()
     # (for QEMU tests)
     export KERNEL_BIN="/boot/vmlinuz-$(uname -r)"
     # Enable kernel debug output for easier debugging when something goes south
-    export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console systemd.default_standard_output=journal+console"
+    export KERNEL_APPEND="debug systemd.log_level=debug rd.systemd.log_target=console systemd.default_standard_output=journal+console"
     # Set timeout for QEMU tests to kill them in case they get stuck
     export QEMU_TIMEOUT=600
     # Disable nspawn version of the test

--- a/vagrant/bootstrap_scripts/arch.sh
+++ b/vagrant/bootstrap_scripts/arch.sh
@@ -67,7 +67,7 @@ touch /etc/mkinitcpio.ci.conf
     mkinitcpio -c /etc/mkinitcpio.ci.conf -A base,systemd,autodetect,modconf,block,filesystems,keyboard,fsck -g "$INITRD"
     # Enable as much debug logging as we can to make debugging easier
     # (especially for boot issues)
-    export KERNEL_APPEND="debug systemd.log_level=debug systemd.log_target=console"
+    export KERNEL_APPEND="debug systemd.log_level=debug rd.systemd.log_target=console"
     export QEMU_TIMEOUT=600
     # Skip the nspawn version of the test
     export TEST_NO_NSPAWN=1


### PR DESCRIPTION
The debug logs are quite noisy and actually slow down the machine boot, as the console becomes oversaturated. Since we store the machine journal anyway let's forward logs to console only in initrd to have something actionable if something blows up during early boot.