### PR TITLE
vagrant: use the official Arch Linux image

### DIFF
--- a/vagrant/bootstrap_scripts/arch.sh
+++ b/vagrant/bootstrap_scripts/arch.sh
@@ -64,7 +64,7 @@ touch /etc/mkinitcpio.ci.conf
     # We need a custom initrd (with the systemd module) for integration tests
     # See vagrant-test.sh for reasoning
     export INITRD="$(mktemp /var/tmp/initrd-testsuite-XXX.img)"
-    mkinitcpio -c /etc/mkinitcpio.ci.conf -A base,systemd,autodetect,modconf,block,filesystems,keyboard,fsck -g "$INITRD"
+    mkinitcpio -c /etc/mkinitcpio.ci.conf -A base,systemd,modconf,block,filesystems,keyboard,fsck -g "$INITRD"
     # Enable as much debug logging as we can to make debugging easier
     # (especially for boot issues)
     export KERNEL_APPEND="debug systemd.log_level=debug rd.systemd.log_target=console"

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -124,15 +124,22 @@ Vagrant.configure("2") do |config|
     sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/ { s/quiet//; s/"$/ console=ttyS0"/ }' /etc/default/grub
     grub-mkconfig -o /boot/grub/grub.cfg
 
+    # Replace systemd-networkd with dhcpcd as the network manager for the default
+    # interface, so we can run the systemd-networkd test suite without having
+    # to worry about the network staying up
+    #
     # Tell systemd-networkd to ignore eth0 netdev, so we can keep it up
     # during the systemd-networkd testsuite
-    cat << EOF > /etc/systemd/network/eth0.network
+    cat >/etc/systemd/network/eth0.network <<EOF
     [Match]
     Name=eth0
 
     [Link]
     Unmanaged=yes
 EOF
-
+    # Remove the image-supplied eth* network file
+    rm -fv /etc/systemd/network/80-dhcp.network
+    # Enable dhcpcd for the eth0 interface
+    systemctl enable dhcpcd@eth0.service
   SHELL
 end

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -16,6 +16,8 @@ Vagrant.configure("2") do |config|
 
     # Pass through /dev/random from the host to the VM
     libvirt.random :model => 'random'
+
+    libvirt.machine_type = "q35"
   end
 
   config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -115,7 +115,7 @@ Vagrant.configure("2") do |config|
     # -serial file:xxx feature. Also, explicitly enable unified cgroups, since
     # the default on Arch is the hybrid hierarchy, which interferes with some
     # tests
-    sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/ { s/quiet//; s/"$/ systemd.unified_cgroup_hierarchy=1 systemd.legacy_systemd_cgroup_controller=0 console=ttyS0"/ }' /etc/default/grub
+    sed -i '/GRUB_CMDLINE_LINUX_DEFAULT/ { s/quiet//; s/"$/ console=ttyS0"/ }' /etc/default/grub
     grub-mkconfig -o /boot/grub/grub.cfg
 
     # Tell systemd-networkd to ignore eth0 netdev, so we can keep it up

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -52,6 +52,7 @@ Vagrant.configure("2") do |config|
     # via ssh
     echo -e 'vagrant\nvagrant' | passwd
     passwd -S root
+    echo "PermitRootLogin yes" >>/etc/ssh/sshd_config
 
     # Create /etc/localtime
     systemd-firstboot --timezone=UTC

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.define :archlinux_systemd
-  config.vm.box = "generic/arch"
+  config.vm.box = "archlinux/archlinux"
   # Don't replace the original Vagrant's insecure key
   config.ssh.insert_key = false
 

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -59,6 +59,9 @@ Vagrant.configure("2") do |config|
     # Create /etc/localtime
     systemd-firstboot --timezone=UTC
 
+    # Change the default locale from C.UTF-8
+    localectl set-locale en_US.UTF-8
+
     # Enable GDM by default (to catch certain systemd-logind related issues)
     systemctl enable gdm.service
     systemctl set-default graphical.target

--- a/vagrant/boxes/Vagrantfile_archlinux_systemd
+++ b/vagrant/boxes/Vagrantfile_archlinux_systemd
@@ -56,11 +56,6 @@ Vagrant.configure("2") do |config|
     # Create /etc/localtime
     systemd-firstboot --timezone=UTC
 
-    # Configure NTP (chronyd)
-    pacman --needed --noconfirm -S chrony
-    systemctl enable --now chronyd
-    systemctl status chronyd
-
     # Enable GDM by default (to catch certain systemd-logind related issues)
     systemctl enable gdm.service
     systemctl set-default graphical.target

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -56,7 +56,7 @@ exectask "lcov_collect-build_dir-ninja-test" "lcov_collect $COVERAGE_DIR/unit-te
 # the kernel command line.
 # The exported INITRD variable is picked up by all following integration tests
 export INITRD="$(mktemp /var/tmp/initrd-testsuite-XXX.img)"
-if ! mkinitcpio -c /dev/null -A base,systemd,sd-encrypt,autodetect,modconf,block,filesystems,keyboard,fsck -g "$INITRD"; then
+if ! mkinitcpio -c /dev/null -A base,systemd,sd-encrypt,modconf,block,filesystems,keyboard,fsck -g "$INITRD"; then
     echo >&2 "Failed to generate initrd, can't continue"
     exit 1
 fi

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -79,12 +79,6 @@ SKIP_LIST=(
 # Prepare environment for the systemd-networkd testsuite
 systemctl disable --now dhcpcd dnsmasq
 systemctl reload dbus.service
-# FIXME
-# As the DHCP lease time in libvirt is quite short, and it's not configurable,
-# yet, let's start a DHCP daemon _only_ for the "master" network device to
-# keep it up during the systemd-networkd testsuite
-systemctl enable --now dhcpcd@eth0.service
-systemctl status dhcpcd@eth0.service
 
 exectask_p "systemd-networkd-tests.py" \
          "/bin/time -v -- timeout -k 60s 60m test/test-network/systemd-networkd-tests.py --build-dir=$BUILD_DIR --debug --with-coverage"

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -102,11 +102,6 @@ if [[ $NSPAWN_EC -eq 0 ]]; then
     # Prepare environment for the systemd-networkd testsuite
     systemctl disable --now dhcpcd dnsmasq
     systemctl reload dbus.service
-    # As the DHCP lease time in libvirt is quite short, and it's not configurable,
-    # yet, let's start a DHCP daemon _only_ for the "master" network device to
-    # keep it up during the systemd-networkd testsuite
-    systemctl enable --now dhcpcd@eth0.service
-    systemctl status dhcpcd@eth0.service
 
     # Run the systemd-networkd testsuite "in the background" while we run other
     # integration tests, since it doesn't require much resources and should not

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -48,7 +48,7 @@ exectask "check-meson-logs-for-sanitizer-errors" "cat $BUILD_DIR/meson-logs/test
 # the kernel command line.
 # The exported INITRD variable is picked up by all following integration tests
 export INITRD="$(mktemp /var/tmp/initrd-testsuite-XXX.img)"
-if ! mkinitcpio -c /dev/null -A base,systemd,sd-encrypt,autodetect,modconf,block,filesystems,keyboard,fsck -g "$INITRD"; then
+if ! mkinitcpio -c /dev/null -A base,systemd,sd-encrypt,modconf,block,filesystems,keyboard,fsck -g "$INITRD"; then
     echo >&2 "Failed to generate initrd, can't continue"
     exit 1
 fi

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -42,7 +42,7 @@ exectask "ninja-test" "meson test -C $BUILD_DIR --print-errorlogs --timeout-mult
 # the kernel command line.
 # The exported INITRD variable is picked up by all following integration tests
 export INITRD="$(mktemp /var/tmp/initrd-testsuite-XXX.img)"
-if ! mkinitcpio -c /etc/mkinitcpio.ci.conf -A base,systemd,sd-encrypt,autodetect,modconf,block,filesystems,keyboard,fsck -g "$INITRD"; then
+if ! mkinitcpio -c /etc/mkinitcpio.ci.conf -A base,systemd,sd-encrypt,modconf,block,filesystems,keyboard,fsck -g "$INITRD"; then
     echo >&2 "Failed to generate initrd, can't continue"
     exit 1
 fi

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -77,12 +77,6 @@ TEST_LIST=(
 # Prepare environment for the systemd-networkd testsuite
 systemctl disable --now dhcpcd dnsmasq
 systemctl reload dbus.service
-# FIXME
-# As the DHCP lease time in libvirt is quite short, and it's not configurable,
-# yet, let's start a DHCP daemon _only_ for the "master" network device to
-# keep it up during the systemd-networkd testsuite
-systemctl enable --now dhcpcd@eth0.service
-systemctl status dhcpcd@eth0.service
 
 for t in "${TEST_LIST[@]}"; do
     exectask_p "${t##*/}" "/bin/time -v -- timeout -k 60s 60m ./$t"

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -55,13 +55,13 @@ if [[ "${VAGRANT_FILE##*/}" == "Vagrantfile_rawhide_selinux" ]]; then
     echo "Using '$BOX_NAME' as the Fedora Rawhide box name"
 
     sed -i "/config.vm.box_url/s/BOX-NAME-PLACEHOLDER/$BOX_NAME/" "$VAGRANT_FILE"
-
-    echo "Installing btrfs-aware packages"
-    dnf -y install centos-release-hyperscale-experimental
-    dnf -y install btrfs-progs kernel libguestfs-tools-c
-    # Add the btrfs-progs package to the guestfs image
-    echo "btrfs-progs" >>/usr/lib64/guestfs/supermin.d/packages
 fi
+
+echo "Installing btrfs-aware packages"
+dnf -y install centos-release-hyperscale-experimental
+dnf -y install btrfs-progs kernel libguestfs-tools-c
+# Add the btrfs-progs package to the guestfs image
+echo "btrfs-progs" >>/usr/lib64/guestfs/supermin.d/packages
 
 # Start a VM described in the Vagrantfile with all provision steps
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -11,7 +11,7 @@
 # around 10 minutes, which is pretty substantial time slice for a CI run, which
 # takes ~45 minutes.
 
-set -eu
+set -eux
 set -o pipefail
 
 EC=0
@@ -39,8 +39,8 @@ sestatus | grep -E "SELinux status:\s*disabled" || setenforce 0
 systemctl -q is-enabled firewalld && systemctl disable --now firewalld
 systemctl restart libvirtd
 
-TEMP_DIR="$(mktemp -d vagrant-cache-XXXXX)"
-pushd "$TEMP_DIR" || { echo >&2 "Can't pushd to $TEMP_DIR"; exit 1; }
+mkdir vagrant_cache
+pushd vagrant_cache
 
 # The URL for Fedora Rawhide Vagrant box changes over time, so let's attempt
 # to get the latest one
@@ -72,7 +72,7 @@ cp "$VAGRANT_FILE" Vagrantfile
 vagrant up --no-tty --provider=libvirt
 # Register a cleanup handler
 # shellcheck disable=SC2064
-trap "cd $PWD && vagrant destroy -f && cd / && rm -fr $TEMP_DIR" EXIT
+trap "cd $PWD && vagrant destroy -f && cd .. && rm -fr vagrant_cache" EXIT
 
 timeout 5m vagrant reload
 case $? in
@@ -89,14 +89,38 @@ case $? in
 esac
 vagrant halt
 
+# Workaround for `virt-{sysprep,resize,...}` - work with the image via qemu directly
+# instead of using libvirt
+export LIBGUESTFS_BACKEND=direct
+
+# A very convoluted way to expand the backing image from the original 20G (ATTOW)
+# to something more usable
+if [[ "${VAGRANT_FILE##*/}" == "Vagrantfile_archlinux_systemd" ]]; then
+    LIBVIRT_IMAGE="/var/lib/libvirt/images/vagrant_cache_archlinux_systemd.img"
+
+    # Convert the qcow2 image back into a raw one so it's easier to manipulate with
+    qemu-img convert -f qcow2 -O raw "$LIBVIRT_IMAGE" image.raw
+    # Prepare a sparse file for the expanded image
+    truncate -r image.raw new_image.raw
+    truncate -s +100G new_image.raw
+    # Expand the last partition in the image
+    LAST_PART="$(virt-filesystems --parts -a image.raw | sort -r | head -n1)"
+    virt-resize --expand "$LAST_PART" image.raw new_image.raw
+    # Convert the new image back to qcow2 and copy it back to the libvirt storage
+    # (and hope for the best)
+    qemu-img convert -f raw -O qcow2 new_image.raw "$LIBVIRT_IMAGE"
+    rm -f image.raw
+    # Check if the new image boots
+    vagrant up
+    vagrant ssh -c 'lsblk; df -h /'
+    vagrant halt
+fi
+
 # Create a box from the VM, so it can be reused later. The box name is suffixed
 # with '-new' to avoid using it immediately in "production".
 # Output file example:
 #   boxes/Vagrantfile_archlinux_systemd => archlinux_systemd-new
 BOX_NAME="${VAGRANT_FILE##*/Vagrantfile_}-new"
-# Workaround for `virt-sysprep` - work with the image via qemu directly
-# instead of using libvirt
-export LIBGUESTFS_BACKEND=direct
 # You guessed it, another workaround - let's include the original
 # Vagrantfile as well, as it usually contains important settings
 # which make the box actually bootable. For this, we need to detect the location

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -120,6 +120,7 @@ vagrant package --no-tty --output "$BOX_NAME" --vagrantfile ~/.vagrant.d/boxes/"
     sed -i '/^Vagrant.configure/a\  config.ssh.username = "root"' Vagrantfile
     sed -i '/^Vagrant.configure/a\  config.ssh.password = "vagrant"' Vagrantfile
     sed -i '/^Vagrant.configure/a\  config.ssh.insert_key = "true"' Vagrantfile
+    sed -i '/^Vagrant.configure/a\  config.vm.synced_folder ".", "/vagrant", disabled: true' Vagrantfile
     vagrant up --no-tty --provider=libvirt
     # shellcheck disable=SC2016
     vagrant ssh -c 'bash -exc "uname -a; id; [[ $UID == 0 ]]"' || INNER_EC=1

--- a/vagrant/vagrantfiles/Vagrantfile_arch
+++ b/vagrant/vagrantfiles/Vagrantfile_arch
@@ -61,6 +61,8 @@ Vagrant.configure("2") do |config|
     # Enable nested KVM
     libvirt.nested = true
     libvirt.cpu_mode = "host-model"
+
+    libvirt.machine_type = "q35"
   end
 
   config.ssh.extra_args = [


### PR DESCRIPTION
Split out of #641, as the UEFI part needs more work.