### PR TITLE
agent(rhel9): use the Q35 chipset with (possibly) TCG

### DIFF
--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -164,7 +164,9 @@ export NSPAWN_TIMEOUT=600
 # See:
 #   - https://bugzilla.redhat.com/show_bug.cgi?id=2060839
 #   - https://access.redhat.com/solutions/6833751
-export QEMU_OPTIONS="-cpu Nehalem"
+#
+# Also, use the Q35 chipset in hopes to work around random early VM lockups
+export QEMU_OPTIONS="-cpu Nehalem -machine type=q35,accel=kvm:tcg"
 
 # Let's re-shuffle the test list a bit by placing the most expensive tests
 # in the front, so they can run in background while we go through the rest


### PR DESCRIPTION
To hopefully work around random early VM lockups I've seen in the RHEL 9 jobs.