### PR TITLE
vagrant(arch): rebuild QEMU with CanoKey support

### DIFF
--- a/vagrant/boxes/archlinux_systemd.sh
+++ b/vagrant/boxes/archlinux_systemd.sh
@@ -77,7 +77,7 @@ popd
 rm -fr netlabel_tools
 
 # Compile & install radvd
-# FIXME: drop once [0] is relesed & lands in Arch Linux
+# FIXME: drop once [0] is released & lands in Arch Linux
 # [0] https://github.com/radvd-project/radvd/pull/141
 pacman --needed --noconfirm -S autoconf automake byacc flex gcc libbsd libtool make pkg-config
 git clone --depth=1 https://github.com/radvd-project/radvd

--- a/vagrant/boxes/archlinux_systemd.sh
+++ b/vagrant/boxes/archlinux_systemd.sh
@@ -64,6 +64,7 @@ install -Dm644 scripts/tgtd.service /usr/lib/systemd/system/tgtd.service
 sed -i '/^ExecStart=\/usr\/sbin\/tgtd/aExecStartPost=\/bin\/sleep 5' /usr/lib/systemd/system/tgtd.service
 popd
 rm -fr tgt
+tgtadm --version
 
 # Compile & install netlabel_tools
 pacman --needed --noconfirm -S autoconf automake gcc libtool make pkg-config
@@ -75,6 +76,7 @@ make -j
 make install
 popd
 rm -fr netlabel_tools
+netlabelctl --help
 
 # Compile & install radvd
 # FIXME: drop once [0] is released & lands in Arch Linux
@@ -88,6 +90,8 @@ make -j
 make install
 popd
 rm -fr radvd
+# radvd returns 1 for both --version and --help, so we need to be a bit more creative here
+(radvd --version || :) |& grep "^Version"
 
 # Compile & install dfuzzer
 pacman --needed --noconfirm -S docbook-xsl gcc glib2 libxslt meson pkg-config
@@ -97,6 +101,7 @@ meson build
 ninja -C build install
 popd
 rm -fr dfuzzer
+dfuzzer --version
 
 # Replace systemd-networkd with dhcpcd as the network manager for the default
 # interface, so we can run the systemd-networkd test suite without having

--- a/vagrant/boxes/archlinux_systemd.sh
+++ b/vagrant/boxes/archlinux_systemd.sh
@@ -49,6 +49,8 @@ systemctl enable gdm.service
 systemctl set-default graphical.target
 systemctl get-default
 
+cd /tmp
+
 # Compile & install tgt (iSCSI target utils)
 pacman --needed --noconfirm -S docbook-xsl libxslt perl-config-general
 git clone --depth=1 https://github.com/fujita/tgt

--- a/vagrant/boxes/archlinux_systemd.sh
+++ b/vagrant/boxes/archlinux_systemd.sh
@@ -30,7 +30,7 @@ pacman --needed --noconfirm -Sy base base-devel bpf btrfs-progs acl audit bash-c
 pacman --needed --noconfirm -S coreutils bind busybox cpio dhclient dhcp dhcpcd diffutils dnsmasq dosfstools e2fsprogs erofs-utils \
     evemu expect fsverity-utils gdb inetutils jq knot keyutils lcov libdwarf libelf mdadm mtools net-tools nfs-utils nftables ntp \
     openbsd-netcat open-iscsi perl-capture-tiny perl-datetime perl-json-xs python-pefile python-pexpect python-psutil python-pyelftools \
-    python-pyparsing python-pytest qemu rsync screen socat squashfs-tools strace stress time tpm2-tools swtpm vim wireguard-tools
+    python-pyparsing python-pytest rsync screen socat squashfs-tools strace stress time tpm2-tools swtpm vim wireguard-tools
 
 # Unlock root account and set its password to 'vagrant' to allow root login
 # via ssh
@@ -104,6 +104,68 @@ ninja -C build install
 popd
 rm -fr dfuzzer
 dfuzzer --version
+
+# Configure a FIDO2 QEMU device using CanoKey
+#
+# This has 2 steps:
+#   1) Build & install canokey-qemu
+#   2) Rebuild QEMU with --enable-canokey
+#
+# After this we should have a CanoKey device available through
+#   qemu-system-x86_64 -usb -device canokey,file=...
+#
+# References:
+#   - https://www.qemu.org/docs/master/system/devices/canokey.html
+#   - https://github.com/canokeys/canokey-qemu
+#
+# 1) Build & install canokey-qemu
+pacman --needed --noconfirm -S cmake gcc make patch pkgconf
+git clone --depth=1 --recursive https://github.com/canokeys/canokey-qemu
+mkdir canokey-qemu/build
+pushd canokey-qemu/build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+make -j
+make install
+popd
+rm -fr canokey-qemu
+pkg-config --libs --cflags canokey-qemu
+
+# 2) Rebuild QEMU with --enable-canokey
+#
+# 2a) Since makepkg won't run under root, we need to create a separate user
+#     and give it access to paswordless sudo
+useradd --create-home builder
+mkdir -p /etc/sudoers.d
+echo "builder ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/builder
+
+# 2b) Patch QEMU's PKGBUILD, rebuild it, and install the rebuilt packages
+pacman --needed --noconfirm -S bison fakeroot flex
+git clone --depth=1 https://gitlab.archlinux.org/archlinux/packaging/packages/qemu.git
+chown -R builder qemu
+pushd qemu
+sed -i 's/^pkgrel=.*$/pkgrel=999/' PKGBUILD
+sed -i '/local configure_options=(/a\    --enable-canokey' PKGBUILD
+# The GPG key ID can be found at https://www.qemu.org/download/
+runuser -u builder -- gpg --receive-keys CEACC9E15534EBABB82D3FA03353C9CEF108B584
+runuser -u builder -- makepkg --noconfirm --needed --clean --syncdeps --rmdeps
+# This part is a bit convoluted, since we can't use makepkg --install or install
+# all the just built packages explicitly, as some of the packages conflict with
+# each other. So, in order to leave dependency resolving on pacman, let's create
+# a local repo from the just built packages and instruct pacman to use it
+repo-add "$PWD/qemu.db.tar.gz" ./*.zst
+cp /etc/pacman.conf pacman.conf
+echo -ne "[qemu]\nSigLevel=Optional\nServer=file://$PWD\n" >>pacman.conf
+# Note: we _need_ to prefix the qemu-base meta package with our local repo name,
+#       otherwise pacman will install the first qemu-base package it encounters,
+#       which would be the regular one from the extras repository
+pacman --noconfirm -Sy qemu/qemu-base --config pacman.conf
+popd
+rm -fr qemu
+qemu-system-x86_64 -usb -device canokey,help
+
+# 2c) Cleanup
+rm /etc/sudoers.d/builder
+userdel -fr builder
 
 # Replace systemd-networkd with dhcpcd as the network manager for the default
 # interface, so we can run the systemd-networkd test suite without having

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -64,7 +64,7 @@ echo "btrfs-progs" >>/usr/lib64/guestfs/supermin.d/packages
 
 # Start a VM described in the Vagrantfile with all provision steps
 export VAGRANT_DRIVER="${VAGRANT_DRIVER:-kvm}"
-export VAGRANT_MEMORY="${VAGRANT_MEMORY:-8192}"
+export VAGRANT_MEMORY="${VAGRANT_MEMORY:-32768}"
 export VAGRANT_CPUS="${VAGRANT_CPUS:-$(nproc)}"
 
 # Provision the VM


### PR DESCRIPTION
In order to test the FIDO2 stuff in systemd, let's make use of the
CanoKey QEMU module [0]. Apart from building & installing just the
canokey-qemu stuff [1], we unfortunately have to rebuild QEMU as well
to actually enable the CanoKey device.

[0] https://www.qemu.org/docs/master/system/devices/canokey.html
[1] https://github.com/canokeys/canokey-qemu