### PR TITLE
Revert "vagrant(arch): pin repos to 2023-09-24 with glibc 2.38-3"

### DIFF
--- a/vagrant/boxes/archlinux_systemd.sh
+++ b/vagrant/boxes/archlinux_systemd.sh
@@ -8,32 +8,6 @@ whoami
 stat /dev/tpm0
 [[ "$(</sys/class/tpm/tpm0/tpm_version_major)" == 2 ]]
 
-# FIXME: pin repos to 2023-09-24 with glibc 2.38-3 until [0] is resolved
-#
-# [0] https://bugs.archlinux.org/task/79810
-cat >/etc/pacman.conf <<\EOF
-[options]
-HoldPkg = pacman glibc
-Architecture = auto
-NoProgressBar
-VerbosePkgLists
-ParallelDownloads = 5
-SigLevel = Required DatabaseOptional
-LocalFileSigLevel = Optional
-
-[core]
-SigLevel = PackageRequired
-Server=https://archive.archlinux.org/repos/2023/09/24/$repo/os/$arch
-
-[extra]
-SigLevel = PackageRequired
-Server=https://archive.archlinux.org/repos/2023/09/24/$repo/os/$arch
-
-[community]
-SigLevel = PackageRequired
-Server=https://archive.archlinux.org/repos/2023/09/24/$repo/os/$arch
-EOF
-
 # Clear Pacman's caches
 pacman --noconfirm -Scc
 rm -fv /var/lib/pacman/sync/*.db
@@ -42,7 +16,7 @@ pacman-key --init
 pacman-key --populate archlinux
 pacman --needed --noconfirm -Sy archlinux-keyring
 # Upgrade the system
-pacman --noconfirm -Syuu
+pacman --noconfirm -Syu
 # Install build dependencies
 # Package groups: base, base-devel
 pacman --needed --noconfirm -Sy base base-devel bpf btrfs-progs acl audit bash-completion clang compiler-rt docbook-xsl \


### PR DESCRIPTION
The original issue [0] got resolved far quicker than I originally anticipated, and the fixed package has already hit the stable repos, so let's revert the workaround as well.

[0] https://bugs.archlinux.org/task/79810

This reverts commit 9500181727a3074e60cef721b82083d022f69e09.