### PR TITLE
vagrant(rawhide): explicitly copy systemd-executor into the initrd

### DIFF
--- a/vagrant/bootstrap_scripts/rawhide-selinux.sh
+++ b/vagrant/bootstrap_scripts/rawhide-selinux.sh
@@ -70,7 +70,7 @@ popd
 # Force relabel on next boot
 fixfiles -v -F onboot
 
-dracut -f --regenerate-all
+dracut --install /usr/lib/systemd/systemd-executor -f --regenerate-all
 
 systemd-analyze set-log-level debug
 systemd-analyze set-log-target console


### PR DESCRIPTION
Until a patched version of dracut is released.