### PR TITLE
Revert "agent(alt): temporarily disable -fsantize=function"

### DIFF
--- a/agent/bootstrap-alt.sh
+++ b/agent/bootstrap-alt.sh
@@ -207,12 +207,6 @@ fi
 # See:
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1827338#c3
 #   https://github.com/systemd/systemd-centos-ci/issues/247
-
-# FIXME (-fno-sanitize=function)
-# systemd's hashmap implementation fails miserably with -fsanitize=function,
-# so let's disable it until [0] is resolved.
-#
-# [0] https://github.com/systemd/systemd/issues/29972
 (
     export CC=clang
     export CXX=clang++
@@ -220,10 +214,10 @@ fi
     # shellcheck disable=SC2064
     trap "[[ -d $BUILD_DIR/meson-logs ]] && cp -r $BUILD_DIR/meson-logs '$LOGDIR'" EXIT
     meson "$BUILD_DIR" \
-        -Dc_args='-Og -fno-omit-frame-pointer -ftrapv -shared-libasan -fno-sanitize=function' \
-        -Dc_link_args="-shared-libasan -fno-sanitize=function" \
-        -Dcpp_args='-Og -fno-omit-frame-pointer -ftrapv -shared-libasan -fno-sanitize=function' \
-        -Dcpp_link_args="-shared-libasan -fno-sanitize=function" \
+        -Dc_args='-Og -fno-omit-frame-pointer -ftrapv -shared-libasan' \
+        -Dc_link_args="-shared-libasan" \
+        -Dcpp_args='-Og -fno-omit-frame-pointer -ftrapv -shared-libasan' \
+        -Dcpp_link_args="-shared-libasan" \
         -Db_asneeded=false `# See the FIXME (--as-needed) above` \
         -Ddebug=true \
         --werror \


### PR DESCRIPTION
Should be resolved by https://github.com/systemd/systemd/pull/29984.

This reverts commit 924889605400828e34c8f05d61e14c045a91f335.