### PR TITLE
vagrant(arch): install default .network files in the Arch job

### DIFF
--- a/vagrant/bootstrap_scripts/arch.sh
+++ b/vagrant/bootstrap_scripts/arch.sh
@@ -50,6 +50,7 @@ meson "$BUILD_DIR" \
       -Dinstall-tests=true \
       -Ddbuspolicydir=/usr/share/dbus-1/system.d \
       -Dlocalegen-path=/usr/bin/locale-gen \
+      "$(grep -q default-network meson_options.txt && echo -Ddefault-network=true)" \
       -Dman=true \
       -Dhtml=true
 ninja -C "$BUILD_DIR"


### PR DESCRIPTION
Since the option is disabled by default, let's enable it in the Arch Linux job to make sure we don't break it in the future.

Resolves: #678