### PR TITLE
Revert "agent(rhel9): pin kernel to kernel-5.14.0-407.el9.x86_64"

### DIFF
--- a/agent/bootstrap-rhel9.sh
+++ b/agent/bootstrap-rhel9.sh
@@ -126,10 +126,6 @@ cmd_retry dnf -y config-manager --add-repo "https://jenkins-systemd.apps.ocp.clo
 cmd_retry dnf -y install --enablerepo epel,epel-next qemu-kvm scsi-target-utils
 cmd_retry dnf -y config-manager --set-disabled "mrc0mmand-systemd-centos-ci-centos9-stream9"
 
-# FIXME: pin kernel to kernel-5.14.0-407.el9.x86_64 until RHEL-22465 is resolved
-cmd_retry dnf -y install "kernel-5.14.0-407.el9.x86_64" "kernel-modules-extra-5.14.0-407.el9.x86_64"
-cmd_retry dnf -y remove "kernel-5.14.0-412.el9.x86_64" "kernel-modules-extra-5.14.0-412.el9.x86_64"
-
 # Fetch the upstream systemd repo
 test -e systemd && rm -rf systemd
 git clone "$REPO_URL" systemd


### PR DESCRIPTION
RHEL-22465 has been resolved and a fixed kernel is already on the mirrors (5.14.0-412.el9.x86_64), so let's revert the kernel pin.

This reverts commit 63dbbd8b44b37557854d6faec8b0e8b9235f1450.