### PR TITLE
Revert "common: tell gdb to use debuginfod if available" 

### DIFF
--- a/agent/testsuite-rhel8.sh
+++ b/agent/testsuite-rhel8.sh
@@ -48,7 +48,10 @@ if [[ $COLLECT_COREDUMPS -ne 0 ]]; then
     fi
 
     # Collect any coredumps that happened during boot
-    exectask "coredumpctl_collect_boot" "coredumpctl_collect"
+    if ! exectask "coredumpctl_collect_boot" "coredumpctl_collect"; then
+        echo >&2 "Detected coredump(s) during system bootup"
+        exit 1
+    fi
 fi
 
 set +e

--- a/agent/testsuite-rhel9-sanitizers.sh
+++ b/agent/testsuite-rhel9-sanitizers.sh
@@ -53,9 +53,6 @@ if ! coredumpctl_init; then
     exit 1
 fi
 
-# Collect any coredumps that happened during boot
-exectask "coredumpctl_collect_boot" "coredumpctl_collect"
-
 centos_ensure_qemu_symlink
 
 if [[ $(cat /proc/sys/user/max_user_namespaces) -le 0 ]]; then

--- a/agent/testsuite-rhel9.sh
+++ b/agent/testsuite-rhel9.sh
@@ -43,7 +43,10 @@ if ! coredumpctl_init; then
 fi
 
 # Collect any coredumps that happened during boot
-exectask "coredumpctl_collect_boot" "coredumpctl_collect"
+if ! exectask "coredumpctl_collect_boot" "coredumpctl_collect"; then
+    echo >&2 "Detected coredump(s) during system bootup"
+    exit 1
+fi
 
 if [[ $(cat /proc/sys/user/max_user_namespaces) -le 0 ]]; then
     echo >&2 "user.max_user_namespaces must be > 0"

--- a/agent/testsuite.sh
+++ b/agent/testsuite.sh
@@ -46,7 +46,10 @@ if ! coredumpctl_init; then
 fi
 
 # Collect any coredumps that happened during boot
-exectask "coredumpctl_collect_boot" "coredumpctl_collect"
+if ! exectask "coredumpctl_collect_boot" "coredumpctl_collect"; then
+    echo >&2 "Detected coredump(s) during system bootup"
+    exit 1
+fi
 
 centos_ensure_qemu_symlink
 

--- a/vagrant/test_scripts/test-arch-coverage.sh
+++ b/vagrant/test_scripts/test-arch-coverage.sh
@@ -35,7 +35,10 @@ if ! coredumpctl_init; then
 fi
 
 # Collect any coredumps that happened during boot
-exectask "coredumpctl_collect_boot" "coredumpctl_collect"
+if ! exectask "coredumpctl_collect_boot" "coredumpctl_collect"; then
+    echo >&2 "Detected coredump(s) during system bootup"
+    exit 1
+fi
 
 # Disable swap, since it seems to cause CPU soft lock-ups in some cases
 swapoff -av

--- a/vagrant/test_scripts/test-arch-sanitizers-clang.sh
+++ b/vagrant/test_scripts/test-arch-sanitizers-clang.sh
@@ -29,9 +29,6 @@ if ! coredumpctl_init; then
     exit 1
 fi
 
-# Collect any coredumps that happened during boot
-exectask "coredumpctl_collect_boot" "coredumpctl_collect"
-
 pushd /build || { echo >&2 "Can't pushd to /build"; exit 1; }
 
 ## Sanitizer-specific options

--- a/vagrant/test_scripts/test-arch.sh
+++ b/vagrant/test_scripts/test-arch.sh
@@ -29,7 +29,10 @@ if ! coredumpctl_init; then
 fi
 
 # Collect any coredumps that happened during boot
-exectask "coredumpctl_collect_boot" "coredumpctl_collect"
+if ! exectask "coredumpctl_collect_boot" "coredumpctl_collect"; then
+    echo >&2 "Detected coredump(s) during system bootup"
+    exit 1
+fi
 
 # Disable swap, since it seems to cause CPU soft lock-ups in some cases
 swapoff -av


### PR DESCRIPTION
gdb should do this automagically [0], so let's drop this (as the option
is apparently not in C9S's gdb even though it supports debuginfod just
fine).

[0] https://wiki.archlinux.org/title/Debuginfod
