### PR TITLE
common: skip submodules when checking out the PR branch

### DIFF
--- a/common/utils.sh
+++ b/common/utils.sh
@@ -173,9 +173,6 @@ git_checkout_pr() {
         esac
     ) || return 1
 
-    # Initialize git submodules, if any
-    git submodule update --init --recursive
-
     _log "Checked out version: $(git describe)"
     git log -1
 }


### PR DESCRIPTION
We don't care about submodules and it causes intermittent errors all over the place.