### PR TITLE
vagrant(rawhide): disable the openh264 repo

### DIFF
--- a/vagrant/boxes/rawhide_selinux.sh
+++ b/vagrant/boxes/rawhide_selinux.sh
@@ -13,6 +13,10 @@ if ! dnf -y update fedora-repos fedora-gpg-keys; then
       update fedora-repos fedora-gpg-keys
 fi
 
+# FIXME: disable the openh264 repo, since it has broken signatures on current Rawhide
+# See: https://pagure.io/releng/issue/12275
+dnf config-manager setopt fedora-cisco-openh264.enabled=0
+
 # Upgrade the system
 dnf upgrade -y
 


### PR DESCRIPTION
Since it has broken signatures on current Rawhide.

See: https://pagure.io/releng/issue/12275