### PR TITLE
vagrant(rawhide): fix SELinux labels on dracut modules

### DIFF
--- a/vagrant/bootstrap_scripts/rawhide-selinux.sh
+++ b/vagrant/bootstrap_scripts/rawhide-selinux.sh
@@ -77,6 +77,8 @@ make -j "$(nproc)"
 # See: https://github.com/dracut-ng/dracut-ng/issues/695
 rm -rf /usr/lib/dracut/modules.d/80test*
 make install
+# Fix SELinux labels on module files
+restorecon -Rv /usr/lib/dracut
 dracut --version
 
 systemd-analyze set-log-level debug

--- a/vagrant/bootstrap_scripts/rawhide-selinux.sh
+++ b/vagrant/bootstrap_scripts/rawhide-selinux.sh
@@ -72,10 +72,6 @@ git clone https://github.com/dracut-ng/dracut-ng
 pushd dracut-ng
 ./configure
 make -j "$(nproc)"
-# FIXME: newer dracut moved test modules under the test/ directory and created
-#         symlinks to the original location, which causes some issues
-# See: https://github.com/dracut-ng/dracut-ng/issues/695
-rm -rf /usr/lib/dracut/modules.d/80test*
 make install
 # Fix SELinux labels on module files
 restorecon -Rv /usr/lib/dracut


### PR DESCRIPTION
Replacing the packaged version with a just built one messes up SELinux
labels, causing AVCs:
```
~# ls -lZ /usr/lib/systemd/system/dracut-pre-udev.service /usr/lib/dracut/modules.d/98dracut-systemd/dracut-pre-udev.service
-rw-r--r--. 1 root root system_u:object_r:systemd_unit_file_t:s0 956 Jul 13 21:26 /usr/lib/dracut/modules.d/98dracut-systemd/dracut-pre-udev.service
lrwxrwxrwx. 1 root root system_u:object_r:systemd_unit_file_t:s0  63 Sep 15 20:00 /usr/lib/systemd/system/dracut-pre-udev.service -> ../../dracut/modules.d/98dracut-systemd/dracut-pre-udev.service
~# make install
...
~# ls -lZ /usr/lib/systemd/system/dracut-pre-udev.service /usr/lib/dracut/modules.d/98dracut-systemd/dracut-pre-udev.service
-rw-r--r--. 1 root root unconfined_u:object_r:admin_home_t:s0        956 Nov 11 03:44 /usr/lib/dracut/modules.d/98dracut-systemd/dracut-pre-udev.service
lrwxrwxrwx. 1 root root unconfined_u:object_r:systemd_unit_file_t:s0  63 Nov 11 03:47 /usr/lib/systemd/system/dracut-pre-udev.service -> ../../dracut/modules.d/98dracut-systemd/dracut-pre-udev.service
```
```
Nov 07 06:15:16 localhost kernel: audit: type=1400 audit(1730960116.481:3): avc:  denied  { read } for  pid=1 comm="systemd" name="dracut-pre-udev.service" dev="vda4" ino=6027 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:admin_home_t:s0 tclass=file permissive=1
Nov 07 06:15:16 localhost kernel: audit: type=1400 audit(1730960116.481:4): avc:  denied  { open } for  pid=1 comm="systemd" path="/usr/lib/dracut/modules.d/98dracut-systemd/dracut-pre-udev.service" dev="vda4" ino=6027 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:admin_home_t:s0 tclass=file permissive=1
Nov 07 06:15:16 localhost kernel: audit: type=1400 audit(1730960116.481:5): avc:  denied  { ioctl } for  pid=1 comm="systemd" path="/usr/lib/dracut/modules.d/98dracut-systemd/dracut-pre-udev.service" dev="vda4" ino=6027 ioctlcmd=0x5401 scontext=system_u:system_r:init_t:s0 tcontext=unconfined_u:object_r:admin_home_t:s0 tclass=file permissive=1
```