### PR TITLE
vagrant(rawhide): install NFS tools

### DIFF
--- a/vagrant/boxes/rawhide_selinux.sh
+++ b/vagrant/boxes/rawhide_selinux.sh
@@ -20,6 +20,8 @@ dnf config-manager setopt fedora-cisco-openh264.enabled=0
 # Upgrade the system
 dnf upgrade -y
 
+# Install NFS tools required by Vagrant's "synced folder" functionality
+dnf install -y nfs-utils libnfs-utils portmap
 # Install build & test dependencies
 dnf install -y attr busybox cryptsetup dnf5-plugins dosfstools fedpkg git jq nc qemu-kvm rpm-build rpmdevtools rust socat \
                strace time tmt tpm2-tss-devel util-linux-script 'python3dist(jinja2)'

--- a/vagrant/vagrant-setup.sh
+++ b/vagrant/vagrant-setup.sh
@@ -8,7 +8,7 @@ LIB_ROOT="$(dirname "$0")/../common"
 # shellcheck source=common/utils.sh
 . "$LIB_ROOT/utils.sh" || exit 1
 
-VAGRANT_PKG_URL="https://releases.hashicorp.com/vagrant/2.4.1/vagrant-2.4.1-1.x86_64.rpm"
+VAGRANT_PKG_URL="https://releases.hashicorp.com/vagrant/2.4.3/vagrant-2.4.3-1.x86_64.rpm"
 WORKAROUNDS_DIR="$(dirname "$(readlink -f "$0")")/workarounds"
 
 set -eu

--- a/vagrant/workarounds/build-shared-libs.sh
+++ b/vagrant/workarounds/build-shared-libs.sh
@@ -8,7 +8,7 @@ set -eu
 set -o pipefail
 
 OUT_DIR="${OUT_DIR:-$PWD}"
-VAGRANT_PKG_URL="https://releases.hashicorp.com/vagrant/2.4.1/vagrant-2.4.1-1.x86_64.rpm"
+VAGRANT_PKG_URL="https://releases.hashicorp.com/vagrant/2.4.3/vagrant-2.4.3-1.x86_64.rpm"
 
 [[ ! -d "$OUT_DIR" ]] && mkdir -p "$OUT_DIR"
 


### PR DESCRIPTION
Vagrant requires this for its "synced folder" functionality. It does
this automagically during machine setup, but there appears to be some
bug in current Rawhide that breaks this process. Let's see if installing
the necessary tools beforehand makes any difference.