### PR TITLE
vagrant(arch): correctly detect where to put sd-boot entries

### DIFF
--- a/vagrant/boxes/archlinux_systemd.sh
+++ b/vagrant/boxes/archlinux_systemd.sh
@@ -169,19 +169,18 @@ MACHINE_ID="$(</etc/machine-id)"
 # we return non-zero if we, for whatever reason, fail to parse the version, just to make
 # debugging easier.
 KERNEL_VER="$(pacman -Ql linux | grep vmlinuz | sed -nr 's/^.+\/([^/]+)\/vmlinuz$/\1/p;tx;q1;:x')"
+BOOT="$(bootctl --print-boot-path)"
 
 bootctl install
-cat >/efi/loader/entries/arch.conf <<EOF
+cat >"$BOOT/loader/entries/arch.conf" <<EOF
 title ArchLinux
 linux /$MACHINE_ID/$KERNEL_VER/linux
 initrd /$MACHINE_ID/$KERNEL_VER/initrd
 options root=UUID=$(findmnt -n -o UUID /) rw console=ttyS0 net.ifnames=0
 EOF
 # Follow the recommended layout from the Boot Loader Specification
-mkdir -p "/efi/$MACHINE_ID/$KERNEL_VER"
-mv -v /boot/vmlinuz-linux "/efi/$MACHINE_ID/$KERNEL_VER/linux"
-mv -v /boot/initramfs-linux.img "/efi/$MACHINE_ID/$KERNEL_VER/initrd"
+mkdir -p "$BOOT/$MACHINE_ID/$KERNEL_VER"
+mv -v /boot/vmlinuz-linux "$BOOT/$MACHINE_ID/$KERNEL_VER/linux"
+mv -v /boot/initramfs-linux.img "$BOOT/$MACHINE_ID/$KERNEL_VER/initrd"
 bootctl status
 pacman -Rcnsu --noconfirm grub
-# shellcheck disable=SC2114
-rm -rf /boot

--- a/vagrant/vagrant-make-cache.sh
+++ b/vagrant/vagrant-make-cache.sh
@@ -103,7 +103,7 @@ if [[ "${VAGRANT_FILE##*/}" == "Vagrantfile_archlinux_systemd" ]]; then
     vagrant ssh -c 'lsblk; df -h /'
     # Also, sanity-check the whole BLS stuff
     # shellcheck disable=SC2016
-    vagrant ssh -c 'sudo bash -xec "ls -lR /efi; cat /etc/machine-id; [[ -e /efi/$(</etc/machine-id)/$(uname -r)/linux ]]"'
+    vagrant ssh -c 'sudo bash -xec "ls -lR $(bootctl -x); cat /etc/machine-id; [[ -e $(bootctl -x)/$(</etc/machine-id)/$(uname -r)/linux ]]"'
     vagrant halt
 fi
 


### PR DESCRIPTION
Since systemd/systemd@28dbee46d5bfdcfa601e80e248dbde22b8d65664 systemd-gpt-auto-generator now mounts ESP to /boot if it's empty, so let's drop some of the grub -> sd-boot migration shenanigans and let bootctl tell us where to put/expect stuff instead of guessing.